### PR TITLE
Disable default features for no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ ark-ff = { version = "0.4", default-features = false }
 ark-ec = { version = "0.4", default-features = false }
 ark-poly = { version = "0.4", default-features = false }
 ark-serialize = { version = "0.4", default-features = false, features = ["derive"] }
-fflonk = { git = "https://github.com/w3f/fflonk" }
-rayon = "1"
-merlin = "3.0"
+fflonk = { git = "https://github.com/w3f/fflonk", default-features = false }
+merlin = { version = "3.0", default-features = false }
+rayon = { version = "1", default-features = false }


### PR DESCRIPTION
Complains for `getrandom` inclusion 