### PR TITLE
Finish no-std port

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,7 +18,7 @@ ark-ed-on-bls12-381-bandersnatch = { version = "0.4", default-features = false }
 
 [features]
 default = []
-std = ["ark-std/std", "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-serialize/std"]
+std = ["ark-std/std", "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-serialize/std", "fflonk/std", "merlin/std"]
 parallel = ["std", "rayon", "ark-std/parallel", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel"]
 print-trace = ["ark-std/print-trace"]
 

--- a/common/src/domain.rs
+++ b/common/src/domain.rs
@@ -2,6 +2,7 @@ use ark_ff::{batch_inversion, FftField, Zero};
 use ark_poly::{DenseUVPolynomial, EvaluationDomain, Evaluations, GeneralEvaluationDomain, Polynomial};
 use ark_poly::univariate::DensePolynomial;
 use ark_std::test_rng;
+use ark_std::{vec, vec::Vec};
 
 use crate::FieldColumn;
 

--- a/common/src/gadgets/booleanity.rs
+++ b/common/src/gadgets/booleanity.rs
@@ -1,6 +1,7 @@
 use ark_ff::{FftField, Field, Zero};
 use ark_poly::{Evaluations, GeneralEvaluationDomain};
 use ark_poly::univariate::DensePolynomial;
+use ark_std::{vec, vec::Vec};
 
 use crate::{Column, const_evals, FieldColumn};
 use crate::domain::Domain;

--- a/common/src/gadgets/fixed_cells.rs
+++ b/common/src/gadgets/fixed_cells.rs
@@ -1,6 +1,7 @@
 use ark_ff::{FftField, Field, Zero};
 use ark_poly::Evaluations;
 use ark_poly::univariate::DensePolynomial;
+use ark_std::{vec, vec::Vec};
 
 use crate::{Column, const_evals, FieldColumn};
 use crate::domain::Domain;

--- a/common/src/gadgets/inner_prod.rs
+++ b/common/src/gadgets/inner_prod.rs
@@ -1,6 +1,7 @@
 use ark_ff::{FftField, Field};
 use ark_poly::{Evaluations, GeneralEvaluationDomain};
 use ark_poly::univariate::DensePolynomial;
+use ark_std::{vec, vec::Vec};
 
 use crate::{Column, FieldColumn};
 use crate::domain::Domain;

--- a/common/src/gadgets/mod.rs
+++ b/common/src/gadgets/mod.rs
@@ -1,6 +1,7 @@
 use ark_ff::{FftField, Field};
 use ark_poly::{Evaluations, GeneralEvaluationDomain};
 use ark_poly::univariate::DensePolynomial;
+use ark_std::vec::Vec;
 
 pub mod booleanity;
 // pub mod inner_prod_pub;

--- a/common/src/gadgets/sw_cond_add.rs
+++ b/common/src/gadgets/sw_cond_add.rs
@@ -1,10 +1,9 @@
-use std::iter;
-
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::{FftField, Field};
 use ark_poly::{Evaluations, GeneralEvaluationDomain};
 use ark_poly::univariate::DensePolynomial;
+use ark_std::{vec, vec::Vec};
 
 use crate::{Column, const_evals, FieldColumn};
 use crate::domain::Domain;
@@ -79,7 +78,7 @@ impl<F, Curve> CondAdd<F, Affine<Curve>> where
                 }
                 Some(*acc)
             });
-        let acc: Vec<_> = iter::once(init)
+        let acc: Vec<_> = ark_std::iter::once(init)
             .chain(acc)
             .collect();
         let init_plus_result = acc.last().unwrap();

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,7 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use ark_ff::{FftField, PrimeField};
 use ark_poly::{EvaluationDomain, Evaluations, GeneralEvaluationDomain, Polynomial};
 use ark_poly::univariate::DensePolynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::{vec, vec::Vec};
 use fflonk::pcs::{Commitment, PCS};
 
 pub mod gadgets;

--- a/common/src/piop.rs
+++ b/common/src/piop.rs
@@ -2,6 +2,7 @@ use ark_ff::PrimeField;
 use ark_poly::Evaluations;
 use ark_poly::univariate::DensePolynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::vec::Vec;
 use fflonk::pcs::Commitment;
 
 use crate::{ColumnsCommited, ColumnsEvaluated};

--- a/common/src/prover.rs
+++ b/common/src/prover.rs
@@ -1,6 +1,7 @@
 use ark_ff::PrimeField;
 use ark_poly::{Evaluations, Polynomial};
 use ark_serialize::CanonicalSerialize;
+use ark_std::vec;
 use fflonk::aggregation::single::aggregate_polys;
 use fflonk::pcs::PCS;
 

--- a/common/src/test_helpers.rs
+++ b/common/src/test_helpers.rs
@@ -1,6 +1,7 @@
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_std::rand::Rng;
 use ark_std::UniformRand;
+use ark_std::vec::Vec;
 
 pub fn random_bitvec<R: Rng>(n: usize, density: f64, rng: &mut R) -> Vec<bool> {
     (0..n)

--- a/common/src/transcript.rs
+++ b/common/src/transcript.rs
@@ -1,6 +1,7 @@
 use ark_ff::PrimeField;
 use ark_poly::GeneralEvaluationDomain;
 use ark_serialize::CanonicalSerialize;
+use ark_std::{vec, vec::Vec};
 use fflonk::pcs::{PCS, PcsParams};
 
 use crate::{ColumnsCommited, ColumnsEvaluated};

--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -1,6 +1,7 @@
 use ark_ff::{Field, PrimeField};
 use ark_serialize::CanonicalSerialize;
 use ark_std::test_rng;
+use ark_std::{vec, vec::Vec};
 use fflonk::pcs::{Commitment, PCS, PcsParams};
 
 use crate::{ColumnsCommited, ColumnsEvaluated, Proof};

--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -20,6 +20,6 @@ ark-ed-on-bls12-381-bandersnatch = { version = "0.4", default-features = false }
 
 [features]
 default = []
-std = ["ark-std/std", "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-serialize/std"]
+std = ["ark-std/std", "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-serialize/std", "merlin/std", "fflonk/std", "common/std"]
 parallel = ["std", "rayon", "ark-std/parallel", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel"]
 print-trace = ["ark-std/print-trace"]

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use fflonk::pcs::PCS;
 
 use common::Proof;
@@ -15,12 +17,11 @@ pub type RingProof<F, CS> = Proof<F, CS, RingCommitments<F, <CS as PCS<F>>::C>, 
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Mul;
-
     use ark_ec::CurveGroup;
     use ark_ed_on_bls12_381_bandersnatch::{Fq, Fr, SWAffine};
     use ark_std::{end_timer, start_timer, test_rng, UniformRand};
     use ark_std::rand::Rng;
+    use ark_std::ops::Mul;
     use fflonk::pcs::PCS;
     use merlin::Transcript;
 

--- a/ring/src/piop/mod.rs
+++ b/ring/src/piop/mod.rs
@@ -1,9 +1,9 @@
-use std::marker::PhantomData;
-
 use ark_ec::AffineRepr;
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::{vec, vec::Vec};
+use ark_std::marker::PhantomData;
 use fflonk::pcs::{Commitment, PCS, PcsParams};
 
 use common::{Column, ColumnsCommited, ColumnsEvaluated, FieldColumn};

--- a/ring/src/piop/params.rs
+++ b/ring/src/piop/params.rs
@@ -3,6 +3,7 @@ use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::{BigInteger, PrimeField};
 use ark_std::rand::Rng;
 use ark_std::UniformRand;
+use ark_std::{vec, vec::Vec};
 
 use common::domain::Domain;
 use common::gadgets::sw_cond_add::AffineColumn;
@@ -90,10 +91,9 @@ impl<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> PiopParams<F, Curve> {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Mul;
-
     use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, Fq, Fr};
     use ark_std::{test_rng, UniformRand};
+    use ark_std::ops::Mul;
 
     use common::domain::Domain;
     use common::test_helpers::cond_sum;

--- a/ring/src/piop/prover.rs
+++ b/ring/src/piop/prover.rs
@@ -1,9 +1,9 @@
-use std::marker::PhantomData;
-
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::PrimeField;
 use ark_poly::Evaluations;
 use ark_poly::univariate::DensePolynomial;
+use ark_std::marker::PhantomData;
+use ark_std::{vec, vec::Vec};
 use fflonk::pcs::Commitment;
 
 use common::{Column, FieldColumn};

--- a/ring/src/piop/verifier.rs
+++ b/ring/src/piop/verifier.rs
@@ -1,4 +1,5 @@
 use ark_ff::PrimeField;
+use ark_std::{vec, vec::Vec};
 use fflonk::pcs::Commitment;
 
 use common::domain::EvaluatedDomain;


### PR DESCRIPTION
The crate was not `no-std` yet.

- missing: `#![cfg_attr(not(feature = "std"), no_std)]`
- use required std types via `ark-std::...`