### PR TITLE
Complete Cargo files

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,6 +2,10 @@
 name = "common"
 version = "0.1.0"
 edition = "2021"
+authors = ["Sergey Vasilyev <swasilyev@gmail.com>"]
+license = "MIT/Apache-2.0"
+description = "Infrastructure for creating plonk-like proofs"
+keywords = ["crypto", "cryptography", "plonk"]
 
 [dependencies]
 ark-std.workspace = true

--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -2,6 +2,10 @@
 name = "ring"
 version = "0.1.0"
 edition = "2021"
+authors = ["Sergey Vasilyev <swasilyev@gmail.com>"]
+license = "MIT/Apache-2.0"
+description = "zk-proof of knowledge of the blinding factor for a Pedersen commitment"
+keywords = ["crypto", "cryptography", "zk-proof"]
 
 [dependencies]
 ark-std.workspace = true


### PR DESCRIPTION
-  Valid license is required by Substrate
    - used the same license as used by @burdges for its projects
- Added description and keywords

---

**In prevision of deploying the crates on `crates.io` consider changing the crates names**

Don't know maybe: 
- `common` → `ring-proof-common`
- `ring` → `ring-proof` or `ring-proof-pedersen` or whatever