### PR TITLE
Serializable ProverKey

### DIFF
--- a/common/src/gadgets/sw_cond_add.rs
+++ b/common/src/gadgets/sw_cond_add.rs
@@ -4,6 +4,7 @@ use ark_ff::{FftField, Field};
 use ark_poly::{Evaluations, GeneralEvaluationDomain};
 use ark_poly::univariate::DensePolynomial;
 use ark_std::{vec, vec::Vec};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use crate::{Column, const_evals, FieldColumn};
 use crate::domain::Domain;
@@ -12,7 +13,7 @@ use crate::gadgets::booleanity::BitColumn;
 
 // A vec of affine points from the prime-order subgroup of the curve whose base field enables FFTs,
 // and its convenience representation as columns of coordinates over the curve's base field.
-#[derive(Clone)]
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct AffineColumn<F: FftField, P: AffineRepr<BaseField=F>> {
     points: Vec<P>,
     pub xs: FieldColumn<F>,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -27,7 +27,7 @@ pub trait Column<F: FftField> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct FieldColumn<F: FftField> {
     // actual (constrained) len of the input in evaluation form
     len: usize,

--- a/ring/src/piop/mod.rs
+++ b/ring/src/piop/mod.rs
@@ -63,7 +63,7 @@ impl<F: PrimeField> ColumnsEvaluated<F> for RingEvaluations<F> {
 }
 
 // Columns commitment to which the verifier knows (or trusts).
-#[derive(Clone)]
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct FixedColumns<F: PrimeField, G: AffineRepr<BaseField=F>> {
     // Public keys of the ring participants in order,
     // followed by the powers-of-2 multiples of the second Pedersen base.
@@ -120,6 +120,7 @@ impl<F: PrimeField, G: AffineRepr<BaseField=F>> FixedColumns<F, G> {
     }
 }
 
+#[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct ProverKey<F: PrimeField, CS: PCS<F>, G: AffineRepr<BaseField=F>> {
     pub(crate) pcs_ck: CS::CK,
     pub(crate) fixed_columns: FixedColumns<F, G>,


### PR DESCRIPTION
Maybe you want to make the `FieldColumn::len` a `u32` instead of `usize`.

Otherwise will be 8 bytes in 64-bit hosts and 4 in wasm. So serialized result will not be portable