### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,19 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
+  build-wasm32:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+      - name: Build
+        run: cargo build --verbose --no-default-features --target wasm32-unknown-unknown
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,21 +2,36 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "**" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "**" ]
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: '-D warnings'
+  RUST_BACKTRACE: 1
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Build
+        run: cargo build --verbose
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Run tests
+        run: cargo test --release


### PR DESCRIPTION
- Separate `build` / `test` jobs
- Add a job to build `wasm32-unknown-unknown` target (so that we can easily avoid accidentally break downstream dependencies)


As you can see, currently [`build-wasm32`](https://github.com/w3f/ring-proof/actions/runs/7048725264/job/19185521387?pr=21) job fails. This is expected as target wasm32 is currently broken

This should pass once https://github.com/w3f/ring-proof/pull/20 gets merged