### PR TITLE
Alternative VK construction

### DIFF
--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -11,7 +11,7 @@ use common::Proof;
 pub use piop::index;
 
 use crate::piop::{RingCommitments, RingEvaluations};
-pub use crate::piop::{params::PiopParams, ProverKey, VerifierKey};
+pub use crate::piop::{params::PiopParams, ProverKey, VerifierKey, FixedColumnsCommitted};
 
 mod piop;
 pub mod ring;

--- a/ring/src/piop/mod.rs
+++ b/ring/src/piop/mod.rs
@@ -130,8 +130,8 @@ pub struct ProverKey<F: PrimeField, CS: PCS<F>, G: AffineRepr<BaseField=F>> {
 
 #[derive(Clone, Debug, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifierKey<F: PrimeField, CS: PCS<F>> {
-    pub pcs_raw_vk: <CS::Params as PcsParams>::RVK,
-    pub fixed_columns_committed: FixedColumnsCommitted<F, CS::C>,
+    pub(crate) pcs_raw_vk: <CS::Params as PcsParams>::RVK,
+    pub(crate) fixed_columns_committed: FixedColumnsCommitted<F, CS::C>,
     //TODO: domain
 }
 
@@ -140,10 +140,10 @@ impl<E: Pairing> VerifierKey<E::ScalarField, KZG<E>> {
         ring: &Ring<E::ScalarField, E, G>,
         kzg_vk: RawKzgVerifierKey<E>,
     ) -> Self {
-        Self::from_commitment_and_kzg_vk::<G>(FixedColumnsCommitted::from_ring(ring), kzg_vk)
+        Self::from_commitment_and_kzg_vk(FixedColumnsCommitted::from_ring(ring), kzg_vk)
     }
 
-    pub fn from_commitment_and_kzg_vk<G: SWCurveConfig<BaseField=E::ScalarField>>(
+    pub fn from_commitment_and_kzg_vk(
         commitment: FixedColumnsCommitted<E::ScalarField, KzgCommitment<E>>,
         kzg_vk: RawKzgVerifierKey<E>,
     ) -> Self {

--- a/ring/src/piop/mod.rs
+++ b/ring/src/piop/mod.rs
@@ -130,8 +130,8 @@ pub struct ProverKey<F: PrimeField, CS: PCS<F>, G: AffineRepr<BaseField=F>> {
 
 #[derive(Clone, Debug, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifierKey<F: PrimeField, CS: PCS<F>> {
-    pub(crate) pcs_raw_vk: <CS::Params as PcsParams>::RVK,
-    pub(crate) fixed_columns_committed: FixedColumnsCommitted<F, CS::C>,
+    pub pcs_raw_vk: <CS::Params as PcsParams>::RVK,
+    pub fixed_columns_committed: FixedColumnsCommitted<F, CS::C>,
     //TODO: domain
 }
 
@@ -140,10 +140,21 @@ impl<E: Pairing> VerifierKey<E::ScalarField, KZG<E>> {
         ring: &Ring<E::ScalarField, E, G>,
         kzg_vk: RawKzgVerifierKey<E>,
     ) -> Self {
+        Self::from_commitment_and_kzg_vk::<G>(FixedColumnsCommitted::from_ring(ring), kzg_vk)
+    }
+
+    pub fn from_commitment_and_kzg_vk<G: SWCurveConfig<BaseField=E::ScalarField>>(
+        commitment: FixedColumnsCommitted<E::ScalarField, KzgCommitment<E>>,
+        kzg_vk: RawKzgVerifierKey<E>,
+    ) -> Self {
         Self {
             pcs_raw_vk: kzg_vk,
-            fixed_columns_committed: FixedColumnsCommitted::from_ring(ring),
+            fixed_columns_committed: commitment,
         }
+    }
+
+    pub fn commitment(&self) -> FixedColumnsCommitted<E::ScalarField, KzgCommitment<E>> {
+        self.fixed_columns_committed.clone()
     }
 }
 


### PR DESCRIPTION
This is useful for application where the raw vk is constant in the application and we persist only the commitment.

Usage example.
1. We rebuild the `VerificationKey` from a new set of public keys
2. We get the commitment (using the introduced `commitment()` method
3. We persist only the commitment
4. When required (i.e. to construct the verifier) we construct `VerificationKey` from the commitment and the application constant raw verification key