### PR TITLE
Workaround while waiting for ark-serialize PR 837

### DIFF
--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -18,6 +18,7 @@ merlin.workspace = true
 rayon = { workspace = true, optional = true }
 common = { path = "../common", default-features = false }
 blake2 = { version = "0.10", default-features = false }
+arrayvec = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 ark-bls12-381 = { version = "0.4", default-features = false, features = ["curve"] }

--- a/ring/src/piop/mod.rs
+++ b/ring/src/piop/mod.rs
@@ -22,11 +22,71 @@ mod prover;
 mod verifier;
 pub mod params;
 
+// Workaround while waiting for https://github.com/arkworks-rs/algebra/pull/837
+// to be on [crates.io](https://crates.io/crates/ark-serialize) (allegedly ark-serialize 0.4.3 )
+mod ark_serialize_837 {
+    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate, Valid, SerializationError, Read};
+
+    #[derive(Clone, CanonicalSerialize)]
+    #[repr(transparent)]
+    pub struct ArrayWrap<T: CanonicalSerialize, const N: usize>(pub [T; N]);
+
+    impl<T: CanonicalDeserialize + CanonicalSerialize, const N: usize>  Valid for ArrayWrap<T, N>
+    {
+        fn check(&self) -> Result<(), SerializationError> {
+            self.0.check()
+        }
+    }
+
+    impl<T: CanonicalDeserialize + CanonicalSerialize, const N: usize> CanonicalDeserialize for ArrayWrap<T, N> {
+        fn deserialize_with_mode<R: Read>(
+            mut reader: R,
+            compress: Compress,
+            validate: Validate,
+        ) -> Result<Self, SerializationError> {
+            let mut array = arrayvec::ArrayVec::<T, N>::new();
+            for _ in 0..N {
+                array.push(T::deserialize_with_mode(&mut reader, compress, Validate::No)?);
+            }
+            if let ark_serialize::Validate::Yes = validate {
+                T::batch_check(array.iter())?
+            }
+            Ok(ArrayWrap(array.into_inner().ok().unwrap()))
+        }
+    }
+
+    impl<T: CanonicalDeserialize + CanonicalSerialize, const N: usize> core::ops::Deref for ArrayWrap<T, N> {
+        type Target = [T; N];
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    // This is expected to panic until https://github.com/arkworks-rs/algebra/pull/837
+    // doesn't land on crates.io
+    #[test]
+    #[should_panic]
+    fn panics_without_ark_serialize_827() {
+        let buf = [0u8; 96];
+        let res = <[ark_bls12_381::G1Affine; 2]>::deserialize_compressed(&buf[..]);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn workaround_waiting_for_ark_serialize_837() {
+        let buf = [0u8; 96];
+        let res = <ArrayWrap<ark_bls12_381::G1Affine, 2>>::deserialize_compressed(&buf[..]);
+        assert!(res.is_err());
+    }
+}
+use ark_serialize_837::*;
+
 #[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct RingCommitments<F: PrimeField, C: Commitment<F>> {
     pub(crate) bits: C,
     pub(crate) inn_prod_acc: C,
-    pub(crate) cond_add_acc: [C; 2],
+    pub(crate) cond_add_acc: ArrayWrap<C, 2>,
     pub(crate) phantom: PhantomData<F>,
 }
 
@@ -43,11 +103,11 @@ impl<F: PrimeField, C: Commitment<F>> ColumnsCommited<F, C> for RingCommitments<
 
 #[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct RingEvaluations<F: PrimeField> {
-    pub(crate) points: [F; 2],
+    pub(crate) points: ArrayWrap<F, 2>,
     pub(crate) ring_selector: F,
     pub(crate) bits: F,
     pub(crate) inn_prod_acc: F,
-    pub(crate) cond_add_acc: [F; 2],
+    pub(crate) cond_add_acc: ArrayWrap<F, 2>,
 }
 
 impl<F: PrimeField> ColumnsEvaluated<F> for RingEvaluations<F> {

--- a/ring/src/piop/prover.rs
+++ b/ring/src/piop/prover.rs
@@ -92,10 +92,10 @@ impl<F, C, Curve> ProverPiop<F, C> for PiopProver<F, Curve>
 
     fn committed_columns<Fun: Fn(&DensePolynomial<F>) -> C>(&self, commit: Fun) -> Self::Commitments {
         let bits = commit(self.bits.as_poly());
-        let cond_add_acc = [
+        let cond_add_acc = super::ArrayWrap([
             commit(self.cond_add.acc.xs.as_poly()),
             commit(self.cond_add.acc.ys.as_poly())
-        ];
+        ]);
         let inn_prod_acc = commit(self.inner_prod.acc.as_poly());
         Self::Commitments {
             bits,
@@ -120,17 +120,17 @@ impl<F, C, Curve> ProverPiop<F, C> for PiopProver<F, Curve>
     }
 
     fn columns_evaluated(&self, zeta: &F) -> Self::Evaluations {
-        let points = [
+        let points = super::ArrayWrap([
             self.points.xs.evaluate(zeta),
             self.points.ys.evaluate(zeta),
-        ];
+        ]);
         let ring_selector = self.ring_selector.evaluate(zeta);
         let bits = self.bits.evaluate(zeta);
         let inn_prod_acc = self.inner_prod.acc.evaluate(zeta);
-        let cond_add_acc = [
+        let cond_add_acc = super::ArrayWrap([
             self.cond_add.acc.xs.evaluate(zeta),
             self.cond_add.acc.ys.evaluate(zeta),
-        ];
+        ]);
         Self::Evaluations {
             points,
             ring_selector,


### PR DESCRIPTION
Currently bad input makes array deserialization to panic.

This is a temporary workaround while we're waiting for https://github.com/arkworks-rs/algebra/pull/837 to land on crates.io (allegedly on ark-serialize 0.4.3).

I added PoC tests, one of which must start failing as soon as the new ark-serialize version is released (this allows us to detect it and remove the workaround)