### PR TITLE
Take references where allowed and re-exports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "common",
     "ring",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -24,7 +24,24 @@ ark-ed-on-bls12-381-bandersnatch = { version = "0.4", default-features = false }
 
 [features]
 default = ["std"]
-std = ["ark-std/std", "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-serialize/std", "fflonk/std", "merlin/std", "getrandom_or_panic/std"]
-parallel = ["std", "rayon", "ark-std/parallel", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel"]
+std = [
+  "ark-std/std",
+  "ark-ff/std",
+  "ark-ec/std",
+  "ark-poly/std",
+  "ark-serialize/std",
+  "fflonk/std",
+  "merlin/std",
+  "getrandom_or_panic/std"
+]
+parallel = [
+  "std",
+  "rayon",
+  "fflonk/parallel",
+  "ark-std/parallel",
+  "ark-ff/parallel",
+  "ark-ec/parallel",
+  "ark-poly/parallel"
+]
 print-trace = ["ark-std/print-trace"]
-
+asm = ["fflonk/asm"]

--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -26,6 +26,30 @@ ark-ed-on-bls12-381-bandersnatch = { version = "0.4", default-features = false }
 
 [features]
 default = []
-std = ["ark-std/std", "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-serialize/std", "merlin/std", "fflonk/std", "common/std"]
-parallel = ["std", "rayon", "ark-std/parallel", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel", "common/parallel"]
-print-trace = ["ark-std/print-trace", "common/print-trace"]
+std = [
+  "ark-std/std",
+  "ark-ff/std",
+  "ark-ec/std",
+  "ark-poly/std",
+  "ark-serialize/std",
+  "merlin/std",
+  "fflonk/std",
+  "common/std"
+]
+parallel = [
+  "std",
+  "rayon",
+  "ark-std/parallel",
+  "ark-ff/parallel",
+  "ark-ec/parallel",
+  "ark-poly/parallel",
+  "common/parallel",
+  "fflonk/parallel"
+]
+print-trace = [
+  "ark-std/print-trace",
+  "common/print-trace"
+]
+asm = [
+  "fflonk/asm"
+]

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -20,11 +20,11 @@ pub mod ring_verifier;
 
 pub type RingProof<F, CS> = Proof<F, CS, RingCommitments<F, <CS as PCS<F>>::C>, RingEvaluations<F>>;
 
-// Crates that are required by the downstream dependencies.
-pub mod prelude {
-    pub use fflonk;
-    pub use merlin;
-}
+/// Polynomial Commitment Schemes.
+pub use fflonk::pcs;
+
+/// Transcript for `RingProver` and `RingVerifier` construction.
+pub use merlin::Transcript;
 
 // Calling the method for a prime-order curve results in an infinite loop.
 pub fn find_complement_point<Curve: SWCurveConfig>() -> Affine<Curve> {

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -20,6 +20,12 @@ pub mod ring_verifier;
 
 pub type RingProof<F, CS> = Proof<F, CS, RingCommitments<F, <CS as PCS<F>>::C>, RingEvaluations<F>>;
 
+// Crates that are required by the downstream dependencies.
+pub mod prelude {
+    pub use fflonk;
+    pub use merlin;
+}
+
 // Calling the method for a prime-order curve results in an infinite loop.
 pub fn find_complement_point<Curve: SWCurveConfig>() -> Affine<Curve> {
     let mut x = Curve::BaseField::zero();

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -74,7 +74,7 @@ mod tests {
         let k = rng.gen_range(0..keyset_size); // prover's secret index
         let pk = pks[k].clone();
 
-        let (prover_key, verifier_key) = index::<_, CS, _>(pcs_params, &piop_params, pks);
+        let (prover_key, verifier_key) = index::<_, CS, _>(&pcs_params, &piop_params, &pks);
 
         // PROOF generation
         let secret = Fr::rand(rng); // prover's secret scalar
@@ -104,7 +104,7 @@ mod tests {
         let keyset_size: usize = rng.gen_range(0..max_keyset_size);
         let pks = random_vec::<SWAffine, _>(keyset_size, rng);
 
-        let (_, verifier_key) = index::<_, KZG::<Bls12_381>, _>(pcs_params, &piop_params, pks.clone());
+        let (_, verifier_key) = index::<_, KZG::<Bls12_381>, _>(&pcs_params, &piop_params, &pks);
 
         let ring = Ring::<_, Bls12_381, _>::with_keys(&piop_params, &pks, &ring_builder_key);
 

--- a/ring/src/piop/mod.rs
+++ b/ring/src/piop/mod.rs
@@ -220,9 +220,9 @@ impl<E: Pairing> VerifierKey<E::ScalarField, KZG<E>> {
 
 
 pub fn index<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>>(
-    pcs_params: CS::Params,
+    pcs_params: &CS::Params,
     piop_params: &PiopParams<F, Curve>,
-    keys: Vec<Affine<Curve>>,
+    keys: &[Affine<Curve>],
 ) -> (ProverKey<F, CS, Affine<Curve>>, VerifierKey<F, CS>) {
     let pcs_ck = pcs_params.ck();
     let pcs_raw_vk = pcs_params.raw_vk();

--- a/ring/src/ring.rs
+++ b/ring/src/ring.rs
@@ -231,7 +231,7 @@ impl<F: PrimeField, KzgCurve: Pairing<ScalarField=F>> RingBuilderKey<F, KzgCurve
 mod tests {
     use ark_bls12_381::{Bls12_381, Fr, G1Affine};
     use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, SWAffine};
-    use ark_std::{test_rng, UniformRand, vec};
+    use ark_std::{test_rng, UniformRand};
     use fflonk::pcs::kzg::KZG;
     use fflonk::pcs::kzg::urs::URS;
     use fflonk::pcs::PCS;
@@ -263,13 +263,13 @@ mod tests {
         let piop_params = PiopParams::setup(domain, h, seed);
 
         let mut ring = TestRing::empty(&piop_params, srs, ring_builder_key.g1);
-        let (monimial_cx, monimial_cy) = get_monomial_commitment(pcs_params.clone(), &piop_params, vec![]);
+        let (monimial_cx, monimial_cy) = get_monomial_commitment(&pcs_params, &piop_params, &[]);
         assert_eq!(ring.cx, monimial_cx);
         assert_eq!(ring.cy, monimial_cy);
 
         let keys = random_vec::<SWAffine, _>(ring.max_keys, rng);
         ring.append(&keys, srs);
-        let (monimial_cx, monimial_cy) = get_monomial_commitment(pcs_params, &piop_params, keys.clone());
+        let (monimial_cx, monimial_cy) = get_monomial_commitment(&pcs_params, &piop_params, &keys);
         assert_eq!(ring.cx, monimial_cx);
         assert_eq!(ring.cy, monimial_cy);
 
@@ -298,8 +298,8 @@ mod tests {
         assert_eq!(ring, same_ring);
     }
 
-    fn get_monomial_commitment(pcs_params: URS<Bls12_381>, piop_params: &PiopParams<Fr, BandersnatchConfig>, keys: Vec<SWAffine>) -> (G1Affine, G1Affine) {
-        let (_, verifier_key) = crate::piop::index::<_, KZG::<Bls12_381>, _>(pcs_params, &piop_params, keys);
+    fn get_monomial_commitment(pcs_params: &URS<Bls12_381>, piop_params: &PiopParams<Fr, BandersnatchConfig>, keys: &[SWAffine]) -> (G1Affine, G1Affine) {
+        let (_, verifier_key) = crate::piop::index::<_, KZG::<Bls12_381>, _>(pcs_params, piop_params, keys);
         let [monimial_cx, monimial_cy] = verifier_key.fixed_columns_committed.points;
         (monimial_cx.0, monimial_cy.0)
     }

--- a/ring/src/ring_prover.rs
+++ b/ring/src/ring_prover.rs
@@ -12,7 +12,6 @@ pub struct RingProver<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=
     piop_params: PiopParams<F, Curve>,
     fixed_columns: FixedColumns<F, Affine<Curve>>,
     k: usize,
-
     plonk_prover: PlonkProver<F, CS, merlin::Transcript>,
 }
 


### PR DESCRIPTION
- Take by reference where allowed (prevents clone in downstream users)
- Re-export `fflonk` and `merlin` as the user needs them anyway 
- Propagate `asm` feature to ark-ff