### PR TITLE
Make keyset size independent of 'hiding' param

### DIFF
--- a/common/src/domain.rs
+++ b/common/src/domain.rs
@@ -85,7 +85,7 @@ impl<F: FftField> Domain<F> {
     /// Set whether we wish to produce a zk-PROOF or not.
     ///
     /// Defaults to `true` and this is only relevant for the prover.
-    pub fn hiding(mut self, value: bool) -> Self {
+    pub fn with_hiding(mut self, value: bool) -> Self {
         self.hiding = value;
         self
     }
@@ -234,7 +234,7 @@ mod tests {
 
         // let domain = GeneralEvaluationDomain::new(1024);
         let n = 1024;
-        let domain = Domain::new(n).hiding(hiding);
+        let domain = Domain::new(n).with_hiding(hiding);
         let z = Fq::rand(rng);
         let domain_eval = EvaluatedDomain::new(domain.domain(), z);
         assert_eq!(domain.l_first.poly.evaluate(&z), domain_eval.l_first);

--- a/common/src/domain.rs
+++ b/common/src/domain.rs
@@ -56,10 +56,7 @@ pub struct Domain<F: FftField> {
 
 impl<F: FftField> Domain<F> {
     /// Construct a new evaluation domain.
-    ///
-    /// `hiding` parameter determines whether we wish to produce a zk-PROOF or not.
-    /// This parameter is only relevant for the prover.
-    pub fn new(n: usize, hiding: bool) -> Self {
+    pub fn new(n: usize) -> Self {
         let domains = Domains::new(n);
         let size = domains.x1.size();
         let capacity = size - ZK_ROWS;
@@ -76,7 +73,7 @@ impl<F: FftField> Domain<F> {
 
         Self {
             domains,
-            hiding,
+            hiding: true,
             capacity,
             not_last_row,
             l_first,
@@ -84,6 +81,15 @@ impl<F: FftField> Domain<F> {
             zk_rows_vanishing_poly,
         }
     }
+
+    /// Set whether we wish to produce a zk-PROOF or not.
+    ///
+    /// Defaults to `true` and this is only relevant for the prover.
+    pub fn hiding(mut self, value: bool) -> Self {
+        self.hiding = value;
+        self
+    }
+
 
     pub(crate) fn divide_by_vanishing_poly<>(
         &self,
@@ -228,7 +234,7 @@ mod tests {
 
         // let domain = GeneralEvaluationDomain::new(1024);
         let n = 1024;
-        let domain = Domain::new(n, hiding);
+        let domain = Domain::new(n).hiding(hiding);
         let z = Fq::rand(rng);
         let domain_eval = EvaluatedDomain::new(domain.domain(), z);
         assert_eq!(domain.l_first.poly.evaluate(&z), domain_eval.l_first);

--- a/common/src/gadgets/inner_prod.rs
+++ b/common/src/gadgets/inner_prod.rs
@@ -104,7 +104,7 @@ mod tests {
 
         let log_n = 10;
         let n = 2usize.pow(log_n);
-        let domain = Domain::new(n, hiding);
+        let domain = Domain::new(n).hiding(hiding);
 
         let a = random_vec(domain.capacity - 1, rng);
         let b = random_vec(domain.capacity - 1, rng);

--- a/common/src/gadgets/inner_prod.rs
+++ b/common/src/gadgets/inner_prod.rs
@@ -104,7 +104,7 @@ mod tests {
 
         let log_n = 10;
         let n = 2usize.pow(log_n);
-        let domain = Domain::new(n).hiding(hiding);
+        let domain = Domain::new(n).with_hiding(hiding);
 
         let a = random_vec(domain.capacity - 1, rng);
         let b = random_vec(domain.capacity - 1, rng);

--- a/common/src/gadgets/sw_cond_add.rs
+++ b/common/src/gadgets/sw_cond_add.rs
@@ -266,7 +266,7 @@ mod tests {
 
         let log_n = 10;
         let n = 2usize.pow(log_n);
-        let domain = Domain::new(n, hiding);
+        let domain = Domain::new(n).hiding(hiding);
         let seed = SWAffine::generator();
 
         let bitmask = random_bitvec(domain.capacity - 1, 0.5, rng);

--- a/common/src/gadgets/sw_cond_add.rs
+++ b/common/src/gadgets/sw_cond_add.rs
@@ -266,7 +266,7 @@ mod tests {
 
         let log_n = 10;
         let n = 2usize.pow(log_n);
-        let domain = Domain::new(n).hiding(hiding);
+        let domain = Domain::new(n).with_hiding(hiding);
         let seed = SWAffine::generator();
 
         let bitmask = random_bitvec(domain.capacity - 1, 0.5, rng);

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -122,7 +122,7 @@ mod tests {
         let setup_degree = 3 * domain_size;
         let pcs_params = CS::setup(setup_degree, rng);
 
-        let domain = Domain::new(domain_size, true);
+        let domain = Domain::new(domain_size);
         let h = SWAffine::rand(rng);
         let seed = find_complement_point::<BandersnatchConfig>();
         let piop_params = PiopParams::setup(domain, h, seed);

--- a/ring/src/piop/params.rs
+++ b/ring/src/piop/params.rs
@@ -13,7 +13,7 @@ pub struct PiopParams<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> {
     // Domain over which the piop is represented.
     pub(crate) domain: Domain<F>,
 
-    // Number of bits used to represent a jubjub scalar.
+    // Number of bits used to represent a scalar.
     pub(crate) scalar_bitlen: usize,
 
     // Length of the part of the column representing the public keys (including the padding).

--- a/ring/src/piop/params.rs
+++ b/ring/src/piop/params.rs
@@ -107,7 +107,7 @@ mod tests {
         let rng = &mut test_rng();
         let h = SWAffine::rand(rng);
         let seed = SWAffine::rand(rng);
-        let domain = Domain::new(1024, false);
+        let domain = Domain::new(1024).hiding(false);
         let params = PiopParams::<Fq, BandersnatchConfig>::setup(domain, h, seed);
         let t = Fr::rand(rng);
         let t_bits = params.scalar_part(t);

--- a/ring/src/piop/params.rs
+++ b/ring/src/piop/params.rs
@@ -107,7 +107,7 @@ mod tests {
         let rng = &mut test_rng();
         let h = SWAffine::rand(rng);
         let seed = SWAffine::rand(rng);
-        let domain = Domain::new(1024).hiding(false);
+        let domain = Domain::new(1024).with_hiding(false);
         let params = PiopParams::<Fq, BandersnatchConfig>::setup(domain, h, seed);
         let t = Fr::rand(rng);
         let t_bits = params.scalar_part(t);

--- a/ring/src/ring.rs
+++ b/ring/src/ring.rs
@@ -259,7 +259,7 @@ mod tests {
         // piop params
         let h = SWAffine::rand(rng);
         let seed = SWAffine::rand(rng);
-        let domain = Domain::new(domain_size, true);
+        let domain = Domain::new(domain_size);
         let piop_params = PiopParams::setup(domain, h, seed);
 
         let mut ring = TestRing::empty(&piop_params, srs, ring_builder_key.g1);
@@ -290,7 +290,7 @@ mod tests {
         // piop params
         let h = SWAffine::rand(rng);
         let seed = SWAffine::rand(rng);
-        let domain = Domain::new(domain_size, true);
+        let domain = Domain::new(domain_size);
         let piop_params = PiopParams::setup(domain, h, seed);
 
         let ring = TestRing::empty(&piop_params, srs, ring_builder_key.g1);

--- a/ring/src/ring_verifier.rs
+++ b/ring/src/ring_verifier.rs
@@ -41,7 +41,7 @@ impl<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>> RingVerifier<
         );
         let seed = self.piop_params.seed;
         let seed_plus_result = (seed + result).into_affine();
-        let domain_eval = EvaluatedDomain::new(self.piop_params.domain.domain(), challenges.zeta, self.piop_params.domain.hiding);
+        let domain_eval = EvaluatedDomain::new(self.piop_params.domain.domain(), challenges.zeta);
 
         let piop = PiopVerifier::init(
             domain_eval,


### PR DESCRIPTION
`Domain::hiding` is used to control whether we want to make the proof zk (or not) by randomizing (or not) the last 3 evaluations of the domain.

Currently, setting this parameter to `false` has the side effect of using the 3 zk-rows to make space for 3 extra items in the keyset part.

This results in the inability to verify a proof that was generated with `hiding = false` in a verifier domain where `hiding = true` (even though this parameter is not really relevant in the verifier's context).

My point is that it would be nice to have, given a certain domain size, a fixed size for the keyset part (regardless of whether hiding is being true or not).

This would also have the added benefit of allowing this parameter (set to `false`) to be leveraged for producing test vectors as well.
