### PR TITLE
Merlin replaced with ark-transcript

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,4 @@ ark-ec = { version = "0.4", default-features = false }
 ark-poly = { version = "0.4", default-features = false }
 ark-serialize = { version = "0.4", default-features = false, features = ["derive"] }
 fflonk = { git = "https://github.com/w3f/fflonk", default-features = false }
-merlin = { version = "3.0", default-features = false }
 rayon = { version = "1", default-features = false }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,10 +14,9 @@ ark-ec.workspace = true
 ark-poly.workspace = true
 ark-serialize.workspace = true
 fflonk.workspace = true
-merlin.workspace = true
 rayon = { workspace = true, optional = true }
 getrandom_or_panic = { version = "0.0.3", default-features = false }
-rand_chacha = { version = "0.3.1", default-features = false }
+rand_core = "0.6"
 
 [dev-dependencies]
 ark-ed-on-bls12-381-bandersnatch = { version = "0.4", default-features = false }
@@ -31,8 +30,8 @@ std = [
   "ark-poly/std",
   "ark-serialize/std",
   "fflonk/std",
-  "merlin/std",
-  "getrandom_or_panic/std"
+  "getrandom_or_panic/std",
+  "rand_core/std"
 ]
 parallel = [
   "std",

--- a/common/src/prover.rs
+++ b/common/src/prover.rs
@@ -7,9 +7,9 @@ use fflonk::pcs::PCS;
 
 use crate::piop::ProverPiop;
 use crate::Proof;
-use crate::transcript::Transcript;
+use crate::transcript::PlonkTranscript;
 
-pub struct PlonkProver<F: PrimeField, CS: PCS<F>, T: Transcript<F, CS>> {
+pub struct PlonkProver<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> {
     // Polynomial commitment scheme committer's key.
     pcs_ck: CS::CK,
     // Transcript,
@@ -17,7 +17,7 @@ pub struct PlonkProver<F: PrimeField, CS: PCS<F>, T: Transcript<F, CS>> {
     transcript_prelude: T,
 }
 
-impl<F: PrimeField, CS: PCS<F>, T: Transcript<F, CS>> PlonkProver<F, CS, T> {
+impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T> {
     pub fn init(pcs_ck: CS::CK,
                 verifier_key: impl CanonicalSerialize, //TODO: a type,
                 empty_transcript: T) -> Self {

--- a/common/src/transcript.rs
+++ b/common/src/transcript.rs
@@ -7,7 +7,7 @@ use rand_core::RngCore;
 
 use crate::{ColumnsCommited, ColumnsEvaluated};
 
-pub trait Transcript<F: PrimeField, CS: PCS<F>>: Clone {
+pub trait PlonkTranscript<F: PrimeField, CS: PCS<F>>: Clone {
     fn add_protocol_params(&mut self, domain: &GeneralEvaluationDomain<F>, pcs_raw_vk: &<CS::Params as PcsParams>::RVK) {
         self._add_serializable(b"domain", domain);
         self._add_serializable(b"pcs_raw_vk", pcs_raw_vk);

--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -7,9 +7,9 @@ use rand_core::RngCore;
 
 use crate::{ColumnsCommited, ColumnsEvaluated, Proof};
 use crate::piop::VerifierPiop;
-use crate::transcript::Transcript;
+use crate::transcript::PlonkTranscript;
 
-pub struct PlonkVerifier<F: PrimeField, CS: PCS<F>, T: Transcript<F, CS>> {
+pub struct PlonkVerifier<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> {
     // Polynomial commitment scheme verifier's key.
     pcs_vk: CS::VK,
     // Transcript,
@@ -17,7 +17,7 @@ pub struct PlonkVerifier<F: PrimeField, CS: PCS<F>, T: Transcript<F, CS>> {
     transcript_prelude: T,
 }
 
-impl<F: PrimeField, CS: PCS<F>, T: Transcript<F, CS>> PlonkVerifier<F, CS, T> {
+impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkVerifier<F, CS, T> {
     pub fn init(pcs_vk: <CS::Params as PcsParams>::VK,
                 verifier_key: &impl CanonicalSerialize,
                 empty_transcript: T) -> Self {

--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -3,7 +3,7 @@ use ark_serialize::CanonicalSerialize;
 use ark_std::{vec, vec::Vec};
 use ark_std::rand::Rng;
 use fflonk::pcs::{Commitment, PCS, PcsParams};
-use rand_chacha::ChaCha20Rng;
+use rand_core::RngCore;
 
 use crate::{ColumnsCommited, ColumnsEvaluated, Proof};
 use crate::piop::VerifierPiop;
@@ -74,7 +74,7 @@ impl<F: PrimeField, CS: PCS<F>, T: Transcript<F, CS>> PlonkVerifier<F, CS, T> {
         proof: &Proof<F, CS, Commitments, Evaluations>,
         n_polys: usize,
         n_constraints: usize,
-    ) -> (Challenges<F>, ChaCha20Rng)
+    ) -> (Challenges<F>, impl RngCore)
         where
             Commitments: ColumnsCommited<F, CS::C>,
             Evaluations: ColumnsEvaluated<F>,

--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -14,11 +14,11 @@ ark-ec.workspace = true
 ark-poly.workspace = true
 ark-serialize.workspace = true
 fflonk.workspace = true
-merlin.workspace = true
 rayon = { workspace = true, optional = true }
 common = { path = "../common", default-features = false }
 blake2 = { version = "0.10", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
+ark-transcript = { git = "https://github.com/w3f/ring-vrf", default-features = false }
 
 [dev-dependencies]
 ark-bls12-381 = { version = "0.4", default-features = false, features = ["curve"] }
@@ -32,7 +32,6 @@ std = [
   "ark-ec/std",
   "ark-poly/std",
   "ark-serialize/std",
-  "merlin/std",
   "fflonk/std",
   "common/std"
 ]

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -50,7 +50,7 @@ pub fn hash_to_curve<A: AffineRepr>(message: &[u8]) -> A {
 #[derive(Clone)]
 pub struct ArkTranscript(ark_transcript::Transcript);
 
-impl<F: PrimeField, CS: PCS<F>> common::transcript::Transcript<F, CS> for ArkTranscript {
+impl<F: PrimeField, CS: PCS<F>> common::transcript::PlonkTranscript<F, CS> for ArkTranscript {
     fn _128_bit_point(&mut self, label: &'static [u8]) -> F {
         self.0.challenge(label).read_reduce()
     }

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -2,8 +2,10 @@
 
 use ark_ec::AffineRepr;
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
-use ark_ff::{One, Zero};
+use ark_ff::{One, PrimeField, Zero};
+use ark_serialize::CanonicalSerialize;
 use ark_std::rand;
+use ark_std::rand::RngCore;
 use fflonk::pcs::PCS;
 
 pub use common::domain::Domain;
@@ -22,9 +24,6 @@ pub type RingProof<F, CS> = Proof<F, CS, RingCommitments<F, <CS as PCS<F>>::C>, 
 
 /// Polynomial Commitment Schemes.
 pub use fflonk::pcs;
-
-/// Transcript for `RingProver` and `RingVerifier` construction.
-pub use merlin::Transcript;
 
 // Calling the method for a prime-order curve results in an infinite loop.
 pub fn find_complement_point<Curve: SWCurveConfig>() -> Affine<Curve> {
@@ -48,6 +47,30 @@ pub fn hash_to_curve<A: AffineRepr>(message: &[u8]) -> A {
     A::rand(rng)
 }
 
+#[derive(Clone)]
+pub struct FS(ark_transcript::Transcript);
+
+impl<F: PrimeField, CS: PCS<F>> common::transcript::Transcript<F, CS> for FS {
+    fn _128_bit_point(&mut self, label: &'static [u8]) -> F {
+        self.0.challenge(label).read_reduce()
+    }
+
+    fn _add_serializable(&mut self, label: &'static [u8], message: &impl CanonicalSerialize) {
+        self.0.label(label);
+        self.0.append(message);
+    }
+
+    fn to_rng(mut self) -> impl RngCore {
+        self.0.challenge(b"transcript_rng")
+    }
+}
+
+impl FS {
+    pub fn new(label: &'static [u8]) -> Self {
+        Self(ark_transcript::Transcript::new_labeled(label))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ark_bls12_381::Bls12_381;
@@ -58,7 +81,6 @@ mod tests {
     use ark_std::ops::Mul;
     use ark_std::rand::Rng;
     use fflonk::pcs::kzg::KZG;
-    use merlin::Transcript;
 
     use common::test_helpers::random_vec;
 
@@ -85,12 +107,12 @@ mod tests {
         // PROOF generation
         let secret = Fr::rand(rng); // prover's secret scalar
         let result = piop_params.h.mul(secret) + pk;
-        let ring_prover = RingProver::init(prover_key, piop_params.clone(), k, Transcript::new(b"ring-vrf-test"));
+        let ring_prover = RingProver::init(prover_key, piop_params.clone(), k, FS::new(b"ring-vrf-test"));
         let t_prove = start_timer!(|| "Prove");
         let proof = ring_prover.prove(secret);
         end_timer!(t_prove);
 
-        let ring_verifier = RingVerifier::init(verifier_key, piop_params, Transcript::new(b"ring-vrf-test"));
+        let ring_verifier = RingVerifier::init(verifier_key, piop_params, FS::new(b"ring-vrf-test"));
         let t_verify = start_timer!(|| "Verify");
         let res = ring_verifier.verify_ring_proof(proof, result.into_affine());
         end_timer!(t_verify);

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -48,9 +48,9 @@ pub fn hash_to_curve<A: AffineRepr>(message: &[u8]) -> A {
 }
 
 #[derive(Clone)]
-pub struct FS(ark_transcript::Transcript);
+pub struct ArkTranscript(ark_transcript::Transcript);
 
-impl<F: PrimeField, CS: PCS<F>> common::transcript::Transcript<F, CS> for FS {
+impl<F: PrimeField, CS: PCS<F>> common::transcript::Transcript<F, CS> for ArkTranscript {
     fn _128_bit_point(&mut self, label: &'static [u8]) -> F {
         self.0.challenge(label).read_reduce()
     }
@@ -65,7 +65,7 @@ impl<F: PrimeField, CS: PCS<F>> common::transcript::Transcript<F, CS> for FS {
     }
 }
 
-impl FS {
+impl ArkTranscript {
     pub fn new(label: &'static [u8]) -> Self {
         Self(ark_transcript::Transcript::new_labeled(label))
     }
@@ -107,12 +107,12 @@ mod tests {
         // PROOF generation
         let secret = Fr::rand(rng); // prover's secret scalar
         let result = piop_params.h.mul(secret) + pk;
-        let ring_prover = RingProver::init(prover_key, piop_params.clone(), k, FS::new(b"ring-vrf-test"));
+        let ring_prover = RingProver::init(prover_key, piop_params.clone(), k, ArkTranscript::new(b"ring-vrf-test"));
         let t_prove = start_timer!(|| "Prove");
         let proof = ring_prover.prove(secret);
         end_timer!(t_prove);
 
-        let ring_verifier = RingVerifier::init(verifier_key, piop_params, FS::new(b"ring-vrf-test"));
+        let ring_verifier = RingVerifier::init(verifier_key, piop_params, ArkTranscript::new(b"ring-vrf-test"));
         let t_verify = start_timer!(|| "Verify");
         let res = ring_verifier.verify_ring_proof(proof, result.into_affine());
         end_timer!(t_verify);

--- a/ring/src/ring_prover.rs
+++ b/ring/src/ring_prover.rs
@@ -3,24 +3,37 @@ use ark_ff::PrimeField;
 use fflonk::pcs::PCS;
 
 use common::prover::PlonkProver;
+use common::transcript::Transcript;
 
 use crate::piop::{FixedColumns, PiopProver, ProverKey};
 use crate::piop::params::PiopParams;
-use crate::{FS, RingProof};
+use crate::RingProof;
 
-pub struct RingProver<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>> {
+pub struct RingProver<F, CS, Curve, T>
+where
+    F: PrimeField,
+    CS: PCS<F>,
+    Curve: SWCurveConfig<BaseField=F>,
+    T: Transcript<F, CS>,
+{
     piop_params: PiopParams<F, Curve>,
     fixed_columns: FixedColumns<F, Affine<Curve>>,
     k: usize,
-    plonk_prover: PlonkProver<F, CS, FS>,
+    plonk_prover: PlonkProver<F, CS, T>,
 }
 
 
-impl<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>> RingProver<F, CS, Curve> {
+impl<F, CS, Curve, T> RingProver<F, CS, Curve, T>
+where
+    F: PrimeField,
+    CS: PCS<F>,
+    Curve: SWCurveConfig<BaseField=F>,
+    T: Transcript<F, CS>,
+{
     pub fn init(prover_key: ProverKey<F, CS, Affine<Curve>>,
                 piop_params: PiopParams<F, Curve>,
                 k: usize,
-                empty_transcript: FS,
+                empty_transcript: T,
     ) -> Self {
         let ProverKey { pcs_ck, fixed_columns, verifier_key } = prover_key;
 

--- a/ring/src/ring_prover.rs
+++ b/ring/src/ring_prover.rs
@@ -3,7 +3,7 @@ use ark_ff::PrimeField;
 use fflonk::pcs::PCS;
 
 use common::prover::PlonkProver;
-use common::transcript::Transcript;
+use common::transcript::PlonkTranscript;
 
 use crate::piop::{FixedColumns, PiopProver, ProverKey};
 use crate::piop::params::PiopParams;
@@ -14,7 +14,7 @@ where
     F: PrimeField,
     CS: PCS<F>,
     Curve: SWCurveConfig<BaseField=F>,
-    T: Transcript<F, CS>,
+    T: PlonkTranscript<F, CS>,
 {
     piop_params: PiopParams<F, Curve>,
     fixed_columns: FixedColumns<F, Affine<Curve>>,
@@ -28,7 +28,7 @@ where
     F: PrimeField,
     CS: PCS<F>,
     Curve: SWCurveConfig<BaseField=F>,
-    T: Transcript<F, CS>,
+    T: PlonkTranscript<F, CS>,
 {
     pub fn init(prover_key: ProverKey<F, CS, Affine<Curve>>,
                 piop_params: PiopParams<F, Curve>,

--- a/ring/src/ring_prover.rs
+++ b/ring/src/ring_prover.rs
@@ -6,13 +6,13 @@ use common::prover::PlonkProver;
 
 use crate::piop::{FixedColumns, PiopProver, ProverKey};
 use crate::piop::params::PiopParams;
-use crate::RingProof;
+use crate::{FS, RingProof};
 
 pub struct RingProver<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>> {
     piop_params: PiopParams<F, Curve>,
     fixed_columns: FixedColumns<F, Affine<Curve>>,
     k: usize,
-    plonk_prover: PlonkProver<F, CS, merlin::Transcript>,
+    plonk_prover: PlonkProver<F, CS, FS>,
 }
 
 
@@ -20,7 +20,7 @@ impl<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>> RingProver<F,
     pub fn init(prover_key: ProverKey<F, CS, Affine<Curve>>,
                 piop_params: PiopParams<F, Curve>,
                 k: usize,
-                empty_transcript: merlin::Transcript,
+                empty_transcript: FS,
     ) -> Self {
         let ProverKey { pcs_ck, fixed_columns, verifier_key } = prover_key;
 

--- a/ring/src/ring_verifier.rs
+++ b/ring/src/ring_verifier.rs
@@ -5,7 +5,7 @@ use fflonk::pcs::{PCS, RawVerifierKey};
 
 use common::domain::EvaluatedDomain;
 use common::piop::VerifierPiop;
-use common::transcript::Transcript;
+use common::transcript::PlonkTranscript;
 use common::verifier::PlonkVerifier;
 
 use crate::piop::{FixedColumnsCommitted, PiopVerifier, VerifierKey};
@@ -17,7 +17,7 @@ where
     F: PrimeField,
     CS: PCS<F>,
     Curve: SWCurveConfig<BaseField=F>,
-    T: Transcript<F, CS>,
+    T: PlonkTranscript<F, CS>,
 {
     piop_params: PiopParams<F, Curve>,
     fixed_columns_committed: FixedColumnsCommitted<F, CS::C>,
@@ -29,7 +29,7 @@ where
     F: PrimeField,
     CS: PCS<F>,
     Curve: SWCurveConfig<BaseField=F>,
-    T: Transcript<F, CS>,
+    T: PlonkTranscript<F, CS>,
 {
     pub fn init(verifier_key: VerifierKey<F, CS>,
                 piop_params: PiopParams<F, Curve>,

--- a/ring/src/ring_verifier.rs
+++ b/ring/src/ring_verifier.rs
@@ -5,22 +5,35 @@ use fflonk::pcs::{PCS, RawVerifierKey};
 
 use common::domain::EvaluatedDomain;
 use common::piop::VerifierPiop;
+use common::transcript::Transcript;
 use common::verifier::PlonkVerifier;
 
 use crate::piop::{FixedColumnsCommitted, PiopVerifier, VerifierKey};
 use crate::piop::params::PiopParams;
-use crate::{FS, RingProof};
+use crate::RingProof;
 
-pub struct RingVerifier<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>> {
+pub struct RingVerifier<F, CS, Curve, T>
+where
+    F: PrimeField,
+    CS: PCS<F>,
+    Curve: SWCurveConfig<BaseField=F>,
+    T: Transcript<F, CS>,
+{
     piop_params: PiopParams<F, Curve>,
     fixed_columns_committed: FixedColumnsCommitted<F, CS::C>,
-    plonk_verifier: PlonkVerifier<F, CS, FS>,
+    plonk_verifier: PlonkVerifier<F, CS, T>,
 }
 
-impl<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>> RingVerifier<F, CS, Curve> {
+impl<F, CS, Curve, T> RingVerifier<F, CS, Curve, T>
+where
+    F: PrimeField,
+    CS: PCS<F>,
+    Curve: SWCurveConfig<BaseField=F>,
+    T: Transcript<F, CS>,
+{
     pub fn init(verifier_key: VerifierKey<F, CS>,
                 piop_params: PiopParams<F, Curve>,
-                empty_transcript: FS,
+                empty_transcript: T,
     ) -> Self {
         let pcs_vk = verifier_key.pcs_raw_vk.prepare();
         let plonk_verifier = PlonkVerifier::init(pcs_vk, &verifier_key, empty_transcript);

--- a/ring/src/ring_verifier.rs
+++ b/ring/src/ring_verifier.rs
@@ -9,18 +9,18 @@ use common::verifier::PlonkVerifier;
 
 use crate::piop::{FixedColumnsCommitted, PiopVerifier, VerifierKey};
 use crate::piop::params::PiopParams;
-use crate::RingProof;
+use crate::{FS, RingProof};
 
 pub struct RingVerifier<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>> {
     piop_params: PiopParams<F, Curve>,
     fixed_columns_committed: FixedColumnsCommitted<F, CS::C>,
-    plonk_verifier: PlonkVerifier<F, CS, merlin::Transcript>,
+    plonk_verifier: PlonkVerifier<F, CS, FS>,
 }
 
 impl<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField=F>> RingVerifier<F, CS, Curve> {
     pub fn init(verifier_key: VerifierKey<F, CS>,
                 piop_params: PiopParams<F, Curve>,
-                empty_transcript: merlin::Transcript,
+                empty_transcript: FS,
     ) -> Self {
         let pcs_vk = verifier_key.pcs_raw_vk.prepare();
         let plonk_verifier = PlonkVerifier::init(pcs_vk, &verifier_key, empty_transcript);


### PR DESCRIPTION
The only thing that we've decided for sure in w3f that we don't want merlin due to [limited implementations](https://merlin.cool/implementations.html) and being tricky to specify. So so far as the simplest solution we have @burdges' ark-transcript. 