### PR TITLE
Padding point gen using Try-And-Increment

### DIFF
--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -18,6 +18,7 @@ rayon = { workspace = true, optional = true }
 common = { path = "../common", default-features = false }
 blake2 = { version = "0.10", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
+rand_chacha = { version = "0.3", default-features = false }
 ark-transcript = { git = "https://github.com/w3f/ring-vrf", default-features = false }
 
 [dev-dependencies]
@@ -25,7 +26,7 @@ ark-bls12-381 = { version = "0.4", default-features = false, features = ["curve"
 ark-ed-on-bls12-381-bandersnatch = { version = "0.4", default-features = false }
 
 [features]
-default = []
+default = [ "std" ]
 std = [
   "ark-std/std",
   "ark-ff/std",
@@ -49,6 +50,4 @@ print-trace = [
   "ark-std/print-trace",
   "common/print-trace"
 ]
-asm = [
-  "fflonk/asm"
-]
+asm = [ "fflonk/asm" ]

--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -18,7 +18,6 @@ rayon = { workspace = true, optional = true }
 common = { path = "../common", default-features = false }
 blake2 = { version = "0.10", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
 ark-transcript = { git = "https://github.com/w3f/ring-vrf", default-features = false }
 
 [dev-dependencies]

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -35,7 +35,7 @@ pub fn find_complement_point<Curve: SWCurveConfig>() -> Affine<Curve> {
     }
 }
 
-// Hash to curve using TAI
+// Try and increment hash to curve.
 pub(crate) fn hash_to_curve<F: PrimeField, Curve: SWCurveConfig<BaseField = F>>(message: &[u8]) -> Affine<Curve> {
     use blake2::Digest;
     let mut seed = message.to_vec();

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -1,10 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use ark_ec::AffineRepr;
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::{One, PrimeField, Zero};
 use ark_serialize::CanonicalSerialize;
-use ark_std::rand;
 use ark_std::rand::RngCore;
 use fflonk::pcs::PCS;
 
@@ -35,16 +33,6 @@ pub fn find_complement_point<Curve: SWCurveConfig>() -> Affine<Curve> {
         }
         x = x + Curve::BaseField::one()
     }
-}
-
-// TODO: switch to better hash to curve when available
-pub fn hash_to_curve<A: AffineRepr>(message: &[u8]) -> A {
-    use blake2::Digest;
-    use ark_std::rand::SeedableRng;
-
-    let seed = blake2::Blake2s::digest(message);
-    let rng = &mut rand::rngs::StdRng::from_seed(seed.into());
-    A::rand(rng)
 }
 
 #[derive(Clone)]

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -39,8 +39,8 @@ pub fn find_complement_point<Curve: SWCurveConfig>() -> Affine<Curve> {
 pub(crate) fn hash_to_curve<F: PrimeField, Curve: SWCurveConfig<BaseField = F>>(message: &[u8]) -> Affine<Curve> {
     use blake2::Digest;
     let mut seed = message.to_vec();
+    let cnt_offset = seed.len();
     seed.push(0);
-    let cnt_offset = seed.len() - 1;
     loop {
         let hash: [u8; 64] = blake2::Blake2b::digest(&seed[..]).into();
         let x = F::from_le_bytes_mod_order(&hash);

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -36,7 +36,7 @@ pub fn find_complement_point<Curve: SWCurveConfig>() -> Affine<Curve> {
 }
 
 // Hash to curve using TAI
-pub fn hash_to_curve<F: PrimeField, Curve: SWCurveConfig<BaseField = F>>(message: &[u8]) -> Affine<Curve> {
+pub(crate) fn hash_to_curve<F: PrimeField, Curve: SWCurveConfig<BaseField = F>>(message: &[u8]) -> Affine<Curve> {
     use blake2::Digest;
     let mut seed = message.to_vec();
     seed.push(0);

--- a/ring/src/piop/params.rs
+++ b/ring/src/piop/params.rs
@@ -32,7 +32,7 @@ pub struct PiopParams<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> {
 
 impl<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> PiopParams<F, Curve> {
     pub fn setup(domain: Domain<F>, h: Affine<Curve>, seed: Affine<Curve>) -> Self {
-        let padding_point = crate::hash_to_curve(b"w3f/ring-proof/common/padding");       
+        let padding_point = crate::hash_to_curve(b"w3f/ring-proof/common/padding");
         let scalar_bitlen = Curve::ScalarField::MODULUS_BIT_SIZE as usize;
         // 1 accounts for the last cells of the points and bits columns that remain unconstrained
         let keyset_part_size = domain.capacity - scalar_bitlen - 1;

--- a/ring/src/piop/params.rs
+++ b/ring/src/piop/params.rs
@@ -32,7 +32,13 @@ pub struct PiopParams<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> {
 
 impl<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> PiopParams<F, Curve> {
     pub fn setup(domain: Domain<F>, h: Affine<Curve>, seed: Affine<Curve>) -> Self {
-        let padding_point = crate::hash_to_curve::<Affine<Curve>>(b"w3f/ring-proof/common/padding");
+        let padding_point = {
+            use ark_std::{rand::SeedableRng, UniformRand};
+            use blake2::Digest;
+            let seed = blake2::Blake2s::digest(b"w3f/ring-proof/common/padding");
+            Affine::<Curve>::rand(&mut rand_chacha::ChaCha20Rng::from_seed(seed.into()))
+        };
+        
         let scalar_bitlen = Curve::ScalarField::MODULUS_BIT_SIZE as usize;
         // 1 accounts for the last cells of the points and bits columns that remain unconstrained
         let keyset_part_size = domain.capacity - scalar_bitlen - 1;

--- a/ring/src/piop/params.rs
+++ b/ring/src/piop/params.rs
@@ -32,13 +32,7 @@ pub struct PiopParams<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> {
 
 impl<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> PiopParams<F, Curve> {
     pub fn setup(domain: Domain<F>, h: Affine<Curve>, seed: Affine<Curve>) -> Self {
-        let padding_point = {
-            use ark_std::{rand::SeedableRng, UniformRand};
-            use blake2::Digest;
-            let seed = blake2::Blake2b::digest(b"w3f/ring-proof/common/padding");
-            Affine::<Curve>::rand(&mut rand_chacha::ChaCha20Rng::from_seed(seed.into()))
-        };
-        
+        let padding_point = crate::hash_to_curve(b"w3f/ring-proof/common/padding");       
         let scalar_bitlen = Curve::ScalarField::MODULUS_BIT_SIZE as usize;
         // 1 accounts for the last cells of the points and bits columns that remain unconstrained
         let keyset_part_size = domain.capacity - scalar_bitlen - 1;

--- a/ring/src/piop/params.rs
+++ b/ring/src/piop/params.rs
@@ -35,7 +35,7 @@ impl<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> PiopParams<F, Curve> {
         let padding_point = {
             use ark_std::{rand::SeedableRng, UniformRand};
             use blake2::Digest;
-            let seed = blake2::Blake2s::digest(b"w3f/ring-proof/common/padding");
+            let seed = blake2::Blake2b::digest(b"w3f/ring-proof/common/padding");
             Affine::<Curve>::rand(&mut rand_chacha::ChaCha20Rng::from_seed(seed.into()))
         };
         

--- a/ring/src/piop/params.rs
+++ b/ring/src/piop/params.rs
@@ -32,7 +32,7 @@ pub struct PiopParams<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> {
 
 impl<F: PrimeField, Curve: SWCurveConfig<BaseField=F>> PiopParams<F, Curve> {
     pub fn setup(domain: Domain<F>, h: Affine<Curve>, seed: Affine<Curve>) -> Self {
-        let padding_point = crate::hash_to_curve(b"w3f/ring-proof/common/padding");
+        let padding_point = crate::hash_to_curve(b"/w3f/ring-proof/padding");
         let scalar_bitlen = Curve::ScalarField::MODULUS_BIT_SIZE as usize;
         // 1 accounts for the last cells of the points and bits columns that remain unconstrained
         let keyset_part_size = domain.capacity - scalar_bitlen - 1;


### PR DESCRIPTION
TAI success is expected - on average - after two iterations.
For Bandersnatch and the given message it succeeded on the first iteration.

Generated padding point:

`(25353312785503880631115876544961443547556511355876709037985429927235015446936, 48034916494481689813223622984827694955476028581467743482028403440447916980403)`

With blake2 we can generate an X for a field with at most 512 bits. I guess this is acceptable (at least for all the curves provided by arkworks). Well, for our usage here, we can probably reduce it to 32 bytes....  
