### PR TITLE
FixedColumnsCommited- pub fields

### DIFF
--- a/ring/src/piop/mod.rs
+++ b/ring/src/piop/mod.rs
@@ -142,8 +142,8 @@ pub struct FixedColumns<F: PrimeField, G: AffineRepr<BaseField=F>> {
 #[derive(Clone, CanonicalSerialize, CanonicalDeserialize, PartialEq, Eq, Debug)]
 pub struct FixedColumnsCommitted<F: PrimeField, C: Commitment<F>> {
     pub points: [C; 2],
-    ring_selector: C,
-    phantom: PhantomData<F>,
+    pub ring_selector: C,
+    pub phantom: PhantomData<F>,
 }
 
 impl<F: PrimeField, C: Commitment<F>> FixedColumnsCommitted<F, C> {


### PR DESCRIPTION
to allow downstream consumers of this struct to build it

in my own code i would like to create this struct.
but i can't since the fields are private

another good option would be to have a "new" constructor