### PR TITLE
EVM-verifiable ring-vrf

### DIFF
--- a/w3f-plonk-common/src/gadgets/column_sum.rs
+++ b/w3f-plonk-common/src/gadgets/column_sum.rs
@@ -41,10 +41,12 @@ impl<F: FftField> ColumnSumPolys<F> {
 
     /// Returns `col[0], col[0] + col[1], ..., col[0] + col[1] + ... + col[n-1]`.
     fn partial_sums(col: &[F]) -> Vec<F> {
-        col.iter().scan(F::zero(), |state, &x| {
-            *state += x;
-            Some(*state)
-        }).collect()
+        col.iter()
+            .scan(F::zero(), |state, &x| {
+                *state += x;
+                Some(*state)
+            })
+            .collect()
     }
 }
 

--- a/w3f-plonk-common/src/gadgets/column_sum.rs
+++ b/w3f-plonk-common/src/gadgets/column_sum.rs
@@ -12,7 +12,7 @@ use crate::{Column, FieldColumn};
 ///
 /// Let `c` be the domain "capacity" (`c = domain.size - ZK_ROWS`).
 /// The gadget populates and constrains a witness column `acc`,
-/// such that `acc[i] = acc[i-1] + col[i-1], i = 1,...,c-1`.
+/// such that `acc[i+1] = acc[i] + col[i], i = 0,...,c-2`.
 /// Then `acc[c-1] = acc[0] + (col[0] + ... + col[c-2]) = acc[0] + sum(col[0..c-1])`.
 /// `acc[0]` and `acc[c-1]` have to be additionally constrained.
 pub struct ColumnSumPolys<F: FftField> {

--- a/w3f-plonk-common/src/gadgets/column_sum.rs
+++ b/w3f-plonk-common/src/gadgets/column_sum.rs
@@ -12,10 +12,10 @@ pub struct ColumnSumPolys<F: FftField> {
     /// Input column.
     /// Should have length `n-1`, where `n` is the domain "capacity" (domain.size - ZK_ROWS):
     /// `col[0], ..., col[n-2]`
-    col: Rc<FieldColumn<F>>,
+    pub col: Rc<FieldColumn<F>>,
     /// Partial sums of `col`: `acc[0] = 0, acc[i] = col[0] + ... + col[i-1], i = 1,...,n-1`
-    acc: Rc<FieldColumn<F>>,
-    not_last: FieldColumn<F>,
+    pub acc: Rc<FieldColumn<F>>,
+    pub not_last: FieldColumn<F>,
 }
 
 pub struct ColumnSumEvals<F: Field> {

--- a/w3f-plonk-common/src/gadgets/column_sum.rs
+++ b/w3f-plonk-common/src/gadgets/column_sum.rs
@@ -1,0 +1,122 @@
+use ark_ff::{FftField, Field};
+use ark_poly::univariate::DensePolynomial;
+use ark_poly::{Evaluations, GeneralEvaluationDomain};
+use ark_std::rc::Rc;
+use ark_std::{vec, vec::Vec};
+
+use crate::domain::Domain;
+use crate::gadgets::{ProverGadget, VerifierGadget};
+use crate::{Column, FieldColumn};
+
+pub struct ColumnSumPolys<F: FftField> {
+    /// Input column.
+    /// Should have length `n-1`, where `n` is the domain "capacity" (domain.size - ZK_ROWS):
+    /// `col[0], ..., col[n-2]`
+    col: Rc<FieldColumn<F>>,
+    /// Partial sums of `col`: `acc[0] = 0, acc[i] = col[0] + ... + col[i-1], i = 1,...,n-1`
+    acc: Rc<FieldColumn<F>>,
+    not_last: FieldColumn<F>,
+}
+
+pub struct ColumnSumEvals<F: Field> {
+    pub col: F,
+    pub acc: F,
+    pub not_last: F,
+}
+
+impl<F: FftField> ColumnSumPolys<F> {
+    pub fn init(col: Rc<FieldColumn<F>>, domain: &Domain<F>) -> Self {
+        assert_eq!(col.len, domain.capacity - 1); // last element is not constrained
+        let partial_sums = Self::partial_sums(col.vals());
+        let mut acc = vec![F::zero()];
+        acc.extend(partial_sums);
+        let acc = domain.private_column(acc);
+        let acc = Rc::new(acc);
+        Self {
+            col,
+            acc,
+            not_last: domain.not_last_row.clone(),
+        }
+    }
+
+    /// Returns `col[0], col[0] + col[1], ..., col[0] + col[1] + ... + col[n-1]`.
+    fn partial_sums(col: &[F]) -> Vec<F> {
+        col.iter().scan(F::zero(), |state, &x| {
+            *state += x;
+            Some(*state)
+        }).collect()
+    }
+}
+
+impl<F: FftField> ProverGadget<F> for ColumnSumPolys<F> {
+    fn witness_columns(&self) -> Vec<DensePolynomial<F>> {
+        vec![self.acc.poly.clone()]
+    }
+
+    fn constraints(&self) -> Vec<Evaluations<F>> {
+        let col = &self.col.evals_4x;
+        let acc = &self.acc.evals_4x;
+        let acc_shifted = &self.acc.shifted_4x();
+        let not_last = &self.not_last.evals_4x;
+        let c = &(&(acc_shifted - acc) - col) * not_last;
+        vec![c]
+    }
+
+    fn constraints_linearized(&self, z: &F) -> Vec<DensePolynomial<F>> {
+        let c = &self.acc.poly * self.not_last.evaluate(z);
+        vec![c]
+    }
+
+    fn domain(&self) -> GeneralEvaluationDomain<F> {
+        self.col.evals.domain()
+    }
+}
+
+impl<F: Field> VerifierGadget<F> for ColumnSumEvals<F> {
+    fn evaluate_constraints_main(&self) -> Vec<F> {
+        let c = (-self.acc - self.col) * self.not_last;
+        vec![c]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_ed_on_bls12_381_bandersnatch::Fq;
+    use ark_ff::Zero;
+    use ark_poly::Polynomial;
+    use ark_std::test_rng;
+
+    use crate::domain::Domain;
+    use crate::test_helpers::random_vec;
+
+    use super::*;
+
+    fn _test_column_sum_gadget(hiding: bool) {
+        let rng = &mut test_rng();
+
+        let log_n = 10;
+        let n = 2usize.pow(log_n);
+        let domain = Domain::new(n, hiding);
+
+        let col = random_vec(domain.capacity - 1, rng);
+        let sum = col.iter().sum();
+        let col = Rc::new(domain.private_column(col));
+
+        let gadget = ColumnSumPolys::<Fq>::init(col, &domain);
+
+        let acc = &gadget.acc.evals.evals;
+        assert!(acc[0].is_zero());
+        assert_eq!(acc[domain.capacity - 1], sum);
+
+        let constraint_poly = gadget.constraints()[0].interpolate_by_ref();
+
+        assert_eq!(constraint_poly.degree(), n);
+        domain.divide_by_vanishing_poly(&constraint_poly);
+    }
+
+    #[test]
+    fn test_column_sum_gadget() {
+        _test_column_sum_gadget(false);
+        _test_column_sum_gadget(true);
+    }
+}

--- a/w3f-plonk-common/src/gadgets/fixed_cells.rs
+++ b/w3f-plonk-common/src/gadgets/fixed_cells.rs
@@ -10,8 +10,6 @@ use crate::{const_evals, Column, FieldColumn};
 
 pub struct FixedCells<F: FftField> {
     col: Rc<FieldColumn<F>>,
-    col_first: F,
-    col_last: F,
     l_first: FieldColumn<F>,
     l_last: FieldColumn<F>,
 }
@@ -27,40 +25,49 @@ pub struct FixedCellsValues<F: Field> {
 impl<F: FftField> FixedCells<F> {
     pub fn init(col: Rc<FieldColumn<F>>, domain: &Domain<F>) -> Self {
         assert_eq!(col.len, domain.capacity);
-        let col_first = col.evals.evals[0];
-        let col_last = col.evals.evals[domain.capacity - 1];
         let l_first = domain.l_first.clone();
         let l_last = domain.l_last.clone();
         Self {
             col,
-            col_first,
-            col_last,
             l_first,
             l_last,
         }
     }
 
     pub fn constraints(&self) -> Vec<Evaluations<F>> {
-        let col = &self.col;
-        let domain = col.domain_4x();
-        let first = &const_evals(self.col_first, domain);
-        let last = &const_evals(self.col_last, domain);
-        let col = &self.col.evals_4x;
-        let l_first = &self.l_first.evals_4x;
-        let l_last = &self.l_last.evals_4x;
-        let c = &(l_first * &(col - first)) + &(l_last * &(col - last));
+        let domain_capacity = self.col.len; // that's an ugly way to learn the capacity, but we've asserted it above.
+        let c = &Self::constraint_cell(&self.col, &self.l_first, 0)
+            + &Self::constraint_cell(&self.col, &self.l_last, domain_capacity - 1);
         vec![c]
     }
 
     pub fn constraints_linearized(&self, _z: &F) -> Vec<DensePolynomial<F>> {
         vec![DensePolynomial::zero()]
     }
+
+    /// Constraints the column `col` to have the value `col[i]` at index `i`.
+    /// `li` should be the `i-th` Lagrange basis polynomial `li = L_i(X)`.
+    /// The constraint polynomial is `c(X) = L_i(X).col(X) - col[i].L_i(X)`.
+    pub fn constraint_cell(col: &FieldColumn<F>, li: &FieldColumn<F>, i: usize) -> Evaluations<F> {
+        let cell_val = col.evals[i];
+        let domain = col.domain_4x();
+        let cell_val = &const_evals(cell_val, domain);
+        let col = &col.evals_4x;
+        let li = &li.evals_4x;
+        li * &(col - cell_val)
+    }
+}
+
+impl<F: Field> FixedCellsValues<F> {
+    pub fn evaluate_for_cell(col_eval: F, li_eval: F, cell_val: F) -> F {
+        li_eval * (col_eval - cell_val)
+    }
 }
 
 impl<F: Field> VerifierGadget<F> for FixedCellsValues<F> {
     fn evaluate_constraints_main(&self) -> Vec<F> {
-        let c =
-            (self.col - self.col_first) * self.l_first + (self.col - self.col_last) * self.l_last;
+        let c = Self::evaluate_for_cell(self.col, self.l_first, self.col_first)
+            + Self::evaluate_for_cell(self.col, self.l_last, self.col_last);
         vec![c]
     }
 }

--- a/w3f-plonk-common/src/gadgets/mod.rs
+++ b/w3f-plonk-common/src/gadgets/mod.rs
@@ -5,10 +5,10 @@ use ark_std::vec::Vec;
 
 pub mod booleanity;
 // pub mod inner_prod_pub;
+pub mod column_sum;
 pub mod ec;
 pub mod fixed_cells;
 pub mod inner_prod;
-pub mod column_sum;
 
 pub trait ProverGadget<F: FftField> {
     // Columns populated by the gadget.

--- a/w3f-plonk-common/src/gadgets/mod.rs
+++ b/w3f-plonk-common/src/gadgets/mod.rs
@@ -8,6 +8,7 @@ pub mod booleanity;
 pub mod ec;
 pub mod fixed_cells;
 pub mod inner_prod;
+pub mod column_sum;
 
 pub trait ProverGadget<F: FftField> {
     // Columns populated by the gadget.

--- a/w3f-plonk-common/src/lib.rs
+++ b/w3f-plonk-common/src/lib.rs
@@ -31,10 +31,10 @@ pub trait Column<F: FftField> {
 #[derive(Clone)]
 pub struct FieldColumn<F: FftField> {
     // actual (constrained) len of the input in evaluation form
-    len: usize,
-    poly: DensePolynomial<F>,
-    evals: Evaluations<F>,
-    evals_4x: Evaluations<F>,
+    pub len: usize,
+    pub poly: DensePolynomial<F>,
+    pub evals: Evaluations<F>,
+    pub evals_4x: Evaluations<F>,
 }
 
 impl<F: FftField> FieldColumn<F> {

--- a/w3f-plonk-common/src/prover.rs
+++ b/w3f-plonk-common/src/prover.rs
@@ -68,8 +68,6 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
         let lin_at_zeta_omega = lin.evaluate(&zeta_omega);
         transcript.add_evaluations(&columns_at_zeta, &lin_at_zeta_omega);
 
-        println!("z= {}", zeta);
-
         let polys_at_zeta = [columns_to_open, vec![quotient_poly]].concat();
         let nus = transcript.get_kzg_aggregation_challenges(polys_at_zeta.len());
         let agg_at_zeta = aggregate_polys(&polys_at_zeta, &nus);

--- a/w3f-ring-proof/src/piop/prover.rs
+++ b/w3f-ring-proof/src/piop/prover.rs
@@ -75,6 +75,7 @@ impl<F: PrimeField, Curve: TECurveConfig<BaseField = F>> PiopProver<F, Curve> {
         }
     }
 
+    // TODO: move to params?
     fn bits_column(
         params: &PiopParams<F, Curve>,
         index_in_keys: usize,

--- a/w3f-ring-vrf-snark/src/lib.rs
+++ b/w3f-ring-vrf-snark/src/lib.rs
@@ -14,7 +14,7 @@ pub use w3f_pcs::pcs;
 pub use w3f_plonk_common::domain::Domain;
 
 mod piop;
-mod ring_vrf;
+// mod ring_vrf;
 pub mod ring_vrf_prover;
 pub mod ring_vrf_verifier;
 
@@ -46,18 +46,14 @@ impl ArkTranscript {
 
 #[cfg(test)]
 mod tests {
-    use ark_bls12_381::Bls12_381;
     use ark_ec::CurveGroup;
     use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, EdwardsAffine, Fq, Fr};
     use ark_std::ops::Mul;
     use ark_std::rand::Rng;
     use ark_std::{end_timer, start_timer, test_rng, UniformRand};
-    use w3f_pcs::pcs::kzg::KZG;
 
     use w3f_plonk_common::test_helpers::random_vec;
 
-    use crate::piop::FixedColumnsCommitted;
-    use crate::ring_vrf::{Ring, RingBuilderKey};
     use crate::ring_vrf_prover::RingProver;
     use crate::ring_vrf_verifier::RingVerifier;
 
@@ -101,29 +97,29 @@ mod tests {
         assert!(res);
     }
 
-    #[test]
-    fn test_lagrangian_commitment() {
-        let rng = &mut test_rng();
-
-        let domain_size = 2usize.pow(9);
-
-        let (pcs_params, piop_params) = setup::<_, KZG<Bls12_381>>(rng, domain_size);
-        let ring_builder_key = RingBuilderKey::from_srs(&pcs_params, domain_size);
-
-        let max_keyset_size = piop_params.keyset_part_size;
-        let keyset_size: usize = rng.gen_range(0..max_keyset_size);
-        let pks = random_vec::<EdwardsAffine, _>(keyset_size, rng);
-
-        let (_, verifier_key) = index::<_, KZG<Bls12_381>, _>(&pcs_params, &piop_params, &pks);
-
-        let ring = Ring::<_, Bls12_381, _>::with_keys(&piop_params, &pks, &ring_builder_key);
-
-        let fixed_columns_committed = FixedColumnsCommitted::from_ring(&ring);
-        assert_eq!(
-            fixed_columns_committed,
-            verifier_key.fixed_columns_committed
-        );
-    }
+    // #[test]
+    // fn test_lagrangian_commitment() {
+    //     let rng = &mut test_rng();
+    //
+    //     let domain_size = 2usize.pow(9);
+    //
+    //     let (pcs_params, piop_params) = setup::<_, KZG<Bls12_381>>(rng, domain_size);
+    //     let ring_builder_key = RingBuilderKey::from_srs(&pcs_params, domain_size);
+    //
+    //     let max_keyset_size = piop_params.keyset_part_size;
+    //     let keyset_size: usize = rng.gen_range(0..max_keyset_size);
+    //     let pks = random_vec::<EdwardsAffine, _>(keyset_size, rng);
+    //
+    //     let (_, verifier_key) = index::<_, KZG<Bls12_381>, _>(&pcs_params, &piop_params, &pks);
+    //
+    //     let ring = Ring::<_, Bls12_381, _>::with_keys(&piop_params, &pks, &ring_builder_key);
+    //
+    //     let fixed_columns_committed = FixedColumnsCommitted::from_ring(&ring);
+    //     assert_eq!(
+    //         fixed_columns_committed,
+    //         verifier_key.fixed_columns_committed
+    //     );
+    // }
 
     fn setup<R: Rng, CS: PCS<Fq>>(
         rng: &mut R,

--- a/w3f-ring-vrf-snark/src/lib.rs
+++ b/w3f-ring-vrf-snark/src/lib.rs
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn test_ring_proof_kzg() {
-        _test_ring_proof::<KZG<Bls12_381>>(2usize.pow(9), 512);
+        _test_ring_proof::<KZG<Bls12_381>>(2usize.pow(9), 500);
     }
 
     #[test]

--- a/w3f-ring-vrf-snark/src/piop/cell_equality.rs
+++ b/w3f-ring-vrf-snark/src/piop/cell_equality.rs
@@ -28,11 +28,7 @@ impl<F: FftField> CellEqualityPolys<F> {
         let b_last = b.evals.evals[domain.capacity - 1];
         assert_eq!(a_last, b_last);
         let l_last = domain.l_last.clone();
-        Self {
-            a,
-            b,
-            l_last,
-        }
+        Self { a, b, l_last }
     }
 
     pub fn constraints(&self) -> Vec<Evaluations<F>> {

--- a/w3f-ring-vrf-snark/src/piop/cell_equality.rs
+++ b/w3f-ring-vrf-snark/src/piop/cell_equality.rs
@@ -1,0 +1,56 @@
+use ark_ff::{FftField, Field, Zero};
+use ark_poly::univariate::DensePolynomial;
+use ark_poly::Evaluations;
+use ark_std::rc::Rc;
+use ark_std::{vec, vec::Vec};
+
+use w3f_plonk_common::domain::Domain;
+use w3f_plonk_common::gadgets::VerifierGadget;
+use w3f_plonk_common::FieldColumn;
+
+pub struct CellEqualityPolys<F: FftField> {
+    a: Rc<FieldColumn<F>>,
+    b: Rc<FieldColumn<F>>,
+    l_last: FieldColumn<F>,
+}
+
+pub struct CellEqualityEvals<F: Field> {
+    pub a: F,
+    pub b: F,
+    pub l_last: F,
+}
+
+impl<F: FftField> CellEqualityPolys<F> {
+    pub fn init(a: Rc<FieldColumn<F>>, b: Rc<FieldColumn<F>>, domain: &Domain<F>) -> Self {
+        assert_eq!(a.len, domain.capacity);
+        assert_eq!(b.len, domain.capacity);
+        let a_last = a.evals.evals[domain.capacity - 1];
+        let b_last = b.evals.evals[domain.capacity - 1];
+        assert_eq!(a_last, b_last);
+        let l_last = domain.l_last.clone();
+        Self {
+            a,
+            b,
+            l_last,
+        }
+    }
+
+    pub fn constraints(&self) -> Vec<Evaluations<F>> {
+        let a = &self.a.evals_4x;
+        let b = &self.b.evals_4x;
+        let l_last = &self.l_last.evals_4x;
+        let c = l_last * &(a - b);
+        vec![c]
+    }
+
+    pub fn constraints_linearized(&self, _z: &F) -> Vec<DensePolynomial<F>> {
+        vec![DensePolynomial::zero()]
+    }
+}
+
+impl<F: Field> VerifierGadget<F> for CellEqualityEvals<F> {
+    fn evaluate_constraints_main(&self) -> Vec<F> {
+        let c = self.l_last * (self.a - self.b);
+        vec![c]
+    }
+}

--- a/w3f-ring-vrf-snark/src/piop/mod.rs
+++ b/w3f-ring-vrf-snark/src/piop/mod.rs
@@ -29,6 +29,7 @@ pub struct RingCommitments<F: PrimeField, C: Commitment<F>> {
     pub(crate) pk_from_sk: [C; 2],
     pub(crate) doublings_of_in: [C; 2],
     pub(crate) out_from_in: [C; 2],
+    pub(crate) pk_from_index: [C; 2],
     pub(crate) phantom: PhantomData<F>,
 }
 
@@ -43,6 +44,8 @@ impl<F: PrimeField, C: Commitment<F>> ColumnsCommited<F, C> for RingCommitments<
             self.doublings_of_in[1].clone(),
             self.out_from_in[0].clone(),
             self.out_from_in[1].clone(),
+            self.pk_from_index[0].clone(),
+            self.pk_from_index[1].clone(),
         ]
     }
 }
@@ -74,6 +77,8 @@ impl<F: PrimeField> ColumnsEvaluated<F> for RingEvaluations<F> {
             self.doublings_of_in[1],
             self.out_from_in[0],
             self.out_from_in[1],
+            self.pk_from_index[0],
+            self.pk_from_index[1],
         ]
     }
 }

--- a/w3f-ring-vrf-snark/src/piop/mod.rs
+++ b/w3f-ring-vrf-snark/src/piop/mod.rs
@@ -56,6 +56,7 @@ pub struct RingEvaluations<F: PrimeField> {
     pub(crate) pk_from_sk: [F; 2],
     pub(crate) doublings_of_in: [F; 2],
     pub(crate) out_from_in: [F; 2],
+    pub(crate) pk_from_index: [F; 2],
 }
 
 impl<F: PrimeField> ColumnsEvaluated<F> for RingEvaluations<F> {

--- a/w3f-ring-vrf-snark/src/piop/mod.rs
+++ b/w3f-ring-vrf-snark/src/piop/mod.rs
@@ -20,6 +20,7 @@ use crate::PiopParams;
 pub mod params;
 mod prover;
 mod verifier;
+mod cell_equality;
 
 #[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct RingCommitments<F: PrimeField, C: Commitment<F>> {

--- a/w3f-ring-vrf-snark/src/piop/mod.rs
+++ b/w3f-ring-vrf-snark/src/piop/mod.rs
@@ -17,10 +17,10 @@ use w3f_plonk_common::{Column, ColumnsCommited, ColumnsEvaluated};
 
 use crate::PiopParams;
 
+mod cell_equality;
 pub mod params;
 mod prover;
 mod verifier;
-mod cell_equality;
 
 #[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct RingCommitments<F: PrimeField, C: Commitment<F>> {

--- a/w3f-ring-vrf-snark/src/piop/mod.rs
+++ b/w3f-ring-vrf-snark/src/piop/mod.rs
@@ -31,6 +31,7 @@ pub struct RingCommitments<F: PrimeField, C: Commitment<F>> {
     pub(crate) doublings_of_in: [C; 2],
     pub(crate) out_from_in: [C; 2],
     pub(crate) pk_from_index: [C; 2],
+    pub(crate) pk_index_sum: C,
     pub(crate) phantom: PhantomData<F>,
 }
 
@@ -47,6 +48,7 @@ impl<F: PrimeField, C: Commitment<F>> ColumnsCommited<F, C> for RingCommitments<
             self.out_from_in[1].clone(),
             self.pk_from_index[0].clone(),
             self.pk_from_index[1].clone(),
+            self.pk_index_sum.clone(),
         ]
     }
 }
@@ -61,6 +63,7 @@ pub struct RingEvaluations<F: PrimeField> {
     pub(crate) doublings_of_in: [F; 2],
     pub(crate) out_from_in: [F; 2],
     pub(crate) pk_from_index: [F; 2],
+    pub(crate) pk_index_sum: F,
 }
 
 impl<F: PrimeField> ColumnsEvaluated<F> for RingEvaluations<F> {
@@ -80,6 +83,7 @@ impl<F: PrimeField> ColumnsEvaluated<F> for RingEvaluations<F> {
             self.out_from_in[1],
             self.pk_from_index[0],
             self.pk_from_index[1],
+            self.pk_index_sum,
         ]
     }
 }

--- a/w3f-ring-vrf-snark/src/piop/params.rs
+++ b/w3f-ring-vrf-snark/src/piop/params.rs
@@ -20,8 +20,6 @@ pub struct PiopParams<F: PrimeField, Curve: TECurveConfig<BaseField = F>> {
     pub keyset_part_size: usize,
     /// The generator used to compute public keys, `pk=sk.G`.
     pub(crate) g: Affine<Curve>,
-    /// Blinding base point.
-    pub(crate) h: Affine<Curve>,
     /// Summation base point.
     pub(crate) seed: Affine<Curve>,
     /// The point used to pad the list of public keys.
@@ -39,7 +37,7 @@ impl<F: PrimeField, Curve: TECurveConfig<BaseField = F>> PiopParams<F, Curve> {
     /// All points should be of an unknown discrete log.
     pub fn setup(
         domain: Domain<F>,
-        h: Affine<Curve>,
+        _h: Affine<Curve>, //TODO: cleanup
         seed: Affine<Curve>,
         padding: Affine<Curve>,
     ) -> Self {
@@ -51,7 +49,6 @@ impl<F: PrimeField, Curve: TECurveConfig<BaseField = F>> PiopParams<F, Curve> {
             scalar_bitlen,
             keyset_part_size,
             g: Affine::<Curve>::generator(),
-            h,
             seed,
             padding,
         }

--- a/w3f-ring-vrf-snark/src/piop/prover.rs
+++ b/w3f-ring-vrf-snark/src/piop/prover.rs
@@ -18,9 +18,9 @@ use w3f_plonk_common::gadgets::ProverGadget;
 use w3f_plonk_common::piop::ProverPiop;
 
 use crate::piop::cell_equality::CellEqualityPolys;
+use w3f_plonk_common::gadgets::column_sum::ColumnSumPolys;
 use w3f_plonk_common::gadgets::ec::te_doubling::Doubling;
 use w3f_plonk_common::Column;
-use w3f_plonk_common::gadgets::column_sum::ColumnSumPolys;
 
 /// The prover's private input is its secret key `sk`.
 /// The public inputs are:
@@ -278,12 +278,36 @@ where
             self.out_from_in_y.constraints(),
             self.pks_equal_x.constraints(),
             self.pks_equal_y.constraints(),
-            vec![FixedCells::constraint_cell(&self.pk_from_sk.acc.xs, &self.domain.l_first, 0)],
-            vec![FixedCells::constraint_cell(&self.pk_from_sk.acc.ys, &self.domain.l_first, 0)],
-            vec![FixedCells::constraint_cell(&self.pk_from_index.acc.xs, &self.domain.l_first, 0)],
-            vec![FixedCells::constraint_cell(&self.pk_from_index.acc.ys, &self.domain.l_first, 0)],
-            vec![FixedCells::constraint_cell(&self.doublings_of_in_gadget.doublings.xs, &self.domain.l_first, 0)],
-            vec![FixedCells::constraint_cell(&self.doublings_of_in_gadget.doublings.ys, &self.domain.l_first, 0)],
+            vec![FixedCells::constraint_cell(
+                &self.pk_from_sk.acc.xs,
+                &self.domain.l_first,
+                0,
+            )],
+            vec![FixedCells::constraint_cell(
+                &self.pk_from_sk.acc.ys,
+                &self.domain.l_first,
+                0,
+            )],
+            vec![FixedCells::constraint_cell(
+                &self.pk_from_index.acc.xs,
+                &self.domain.l_first,
+                0,
+            )],
+            vec![FixedCells::constraint_cell(
+                &self.pk_from_index.acc.ys,
+                &self.domain.l_first,
+                0,
+            )],
+            vec![FixedCells::constraint_cell(
+                &self.doublings_of_in_gadget.doublings.xs,
+                &self.domain.l_first,
+                0,
+            )],
+            vec![FixedCells::constraint_cell(
+                &self.doublings_of_in_gadget.doublings.ys,
+                &self.domain.l_first,
+                0,
+            )],
         ]
         .concat()
     }

--- a/w3f-ring-vrf-snark/src/piop/prover.rs
+++ b/w3f-ring-vrf-snark/src/piop/prover.rs
@@ -3,7 +3,7 @@ use ark_ff::PrimeField;
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::Evaluations;
 use ark_std::{vec, vec::Vec};
-use std::rc::Rc;
+use ark_std::rc::Rc;
 use w3f_pcs::pcs::Commitment;
 
 use crate::piop::params::PiopParams;

--- a/w3f-ring-vrf-snark/src/piop/prover.rs
+++ b/w3f-ring-vrf-snark/src/piop/prover.rs
@@ -169,12 +169,17 @@ where
             commit(self.out_from_in.acc.xs.as_poly()),
             commit(self.out_from_in.acc.ys.as_poly()),
         ];
+        let pk_from_index = [
+            commit(self.pk_from_index_x.acc.as_poly()),
+            commit(self.pk_from_index_y.acc.as_poly()),
+        ];
         RingCommitments {
             sk_bits,
             pk_index,
             pk_from_sk,
             doublings_of_in,
             out_from_in,
+            pk_from_index,
             phantom: Default::default(),
         }
     }
@@ -236,12 +241,15 @@ where
     fn constraints(&self) -> Vec<Evaluations<F>> {
         [
             self.sk_bits_bool.constraints(),
+            self.pk_index_bool.constraints(),
             self.pk_from_sk.constraints(),
             self.doublings_of_in_gadget.constraints(),
             self.out_from_in.constraints(),
+            self.pk_from_index_x.constraints(),
+            self.pk_from_index_y.constraints(),
             self.out_from_in_x.constraints(),
             self.out_from_in_y.constraints(),
-            self.pk_index_bool.constraints(),
+
         ]
         .concat()
     }
@@ -249,12 +257,14 @@ where
     fn constraints_lin(&self, zeta: &F) -> Vec<DensePolynomial<F>> {
         [
             self.sk_bits_bool.constraints_linearized(zeta),
+            self.pk_index_bool.constraints_linearized(zeta),
             self.pk_from_sk.constraints_linearized(zeta),
             self.doublings_of_in_gadget.constraints_linearized(zeta),
             self.out_from_in.constraints_linearized(zeta),
+            self.pk_from_index_x.constraints_linearized(zeta),
+            self.pk_from_index_y.constraints_linearized(zeta),
             self.out_from_in_x.constraints_linearized(zeta),
             self.out_from_in_y.constraints_linearized(zeta),
-            self.pk_index_bool.constraints_linearized(zeta),
         ]
         .concat()
     }

--- a/w3f-ring-vrf-snark/src/piop/prover.rs
+++ b/w3f-ring-vrf-snark/src/piop/prover.rs
@@ -2,8 +2,8 @@ use ark_ec::twisted_edwards::{Affine, TECurveConfig};
 use ark_ff::PrimeField;
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::Evaluations;
-use ark_std::{vec, vec::Vec};
 use ark_std::rc::Rc;
+use ark_std::{vec, vec::Vec};
 use w3f_pcs::pcs::Commitment;
 
 use crate::piop::params::PiopParams;

--- a/w3f-ring-vrf-snark/src/piop/prover.rs
+++ b/w3f-ring-vrf-snark/src/piop/prover.rs
@@ -17,9 +17,9 @@ use w3f_plonk_common::gadgets::fixed_cells::FixedCells;
 use w3f_plonk_common::gadgets::ProverGadget;
 use w3f_plonk_common::piop::ProverPiop;
 
+use crate::piop::cell_equality::CellEqualityPolys;
 use w3f_plonk_common::gadgets::ec::te_doubling::Doubling;
 use w3f_plonk_common::Column;
-use crate::piop::cell_equality::CellEqualityPolys;
 
 /// The prover's private input is its secret key `sk`.
 /// The public inputs are:
@@ -114,22 +114,17 @@ impl<F: PrimeField, Curve: TECurveConfig<BaseField = F>> PiopProver<F, Curve> {
         let out_from_in_y = FixedCells::init(out_from_in.acc.ys.clone(), &domain);
 
         let pk_index_bool = Booleanity::init(pk_index.clone());
-        let pk_from_index = CondAdd::init(
-            pk_index.clone(),
-            pks.clone(),
-            params.seed,
-            &domain,
-        );
+        let pk_from_index = CondAdd::init(pk_index.clone(), pks.clone(), params.seed, &domain);
 
         let pks_equal_x = CellEqualityPolys::init(
             pk_from_index.acc.xs.clone(),
             pk_from_sk.acc.xs.clone(),
-            &domain
+            &domain,
         );
         let pks_equal_y = CellEqualityPolys::init(
             pk_from_index.acc.ys.clone(),
             pk_from_sk.acc.ys.clone(),
-            &domain
+            &domain,
         );
 
         Self {

--- a/w3f-ring-vrf-snark/src/piop/prover.rs
+++ b/w3f-ring-vrf-snark/src/piop/prover.rs
@@ -212,6 +212,10 @@ where
     // Self::Evaluations::to_vec() and Self::Commitments::to_vec().
     fn columns(&self) -> Vec<DensePolynomial<F>> {
         vec![
+            self.pks.xs.as_poly().clone(),
+            self.pks.ys.as_poly().clone(),
+            self.doublings_of_g.xs.as_poly().clone(),
+            self.doublings_of_g.ys.as_poly().clone(),
             self.sk_bits.as_poly().clone(),
             self.pk_index.as_poly().clone(),
             self.pk_from_sk.acc.xs.as_poly().clone(),

--- a/w3f-ring-vrf-snark/src/piop/prover.rs
+++ b/w3f-ring-vrf-snark/src/piop/prover.rs
@@ -107,10 +107,6 @@ impl<F: PrimeField, Curve: TECurveConfig<BaseField = F>> PiopProver<F, Curve> {
             &domain,
         );
 
-        let pk_index_bool = Booleanity::init(pk_index.clone());
-        let pk_from_index_x = InnerProd::init(pks.xs.clone(), pk_index.col.clone(), &domain);
-        let pk_from_index_y = InnerProd::init(pks.ys.clone(), pk_index.col.clone(), &domain);
-
         let doublings_of_in_gadget = Doubling::init(vrf_in, &domain);
         let doublings_of_in = doublings_of_in_gadget.doublings.clone();
         let out_from_in = CondAdd::init(
@@ -121,6 +117,10 @@ impl<F: PrimeField, Curve: TECurveConfig<BaseField = F>> PiopProver<F, Curve> {
         );
         let out_from_in_x = FixedCells::init(out_from_in.acc.xs.clone(), &domain);
         let out_from_in_y = FixedCells::init(out_from_in.acc.ys.clone(), &domain);
+
+        let pk_index_bool = Booleanity::init(pk_index.clone());
+        let pk_from_index_x = InnerProd::init(pks.xs.clone(), pk_index.col.clone(), &domain);
+        let pk_from_index_y = InnerProd::init(pks.ys.clone(), pk_index.col.clone(), &domain);
 
         Self {
             domain,
@@ -217,6 +217,10 @@ where
             self.out_from_in.acc.xs.evaluate(zeta),
             self.out_from_in.acc.ys.evaluate(zeta),
         ];
+        let pk_from_index = [
+            self.pk_from_index_x.acc.evaluate(zeta),
+            self.pk_from_index_y.acc.evaluate(zeta),
+        ];
         RingEvaluations {
             pks,
             doublings_of_g,
@@ -225,6 +229,7 @@ where
             pk_from_sk,
             doublings_of_in,
             out_from_in,
+            pk_from_index,
         }
     }
 
@@ -236,6 +241,7 @@ where
             self.out_from_in.constraints(),
             self.out_from_in_x.constraints(),
             self.out_from_in_y.constraints(),
+            self.pk_index_bool.constraints(),
         ]
         .concat()
     }
@@ -248,6 +254,7 @@ where
             self.out_from_in.constraints_linearized(zeta),
             self.out_from_in_x.constraints_linearized(zeta),
             self.out_from_in_y.constraints_linearized(zeta),
+            self.pk_index_bool.constraints_linearized(zeta),
         ]
         .concat()
     }

--- a/w3f-ring-vrf-snark/src/piop/verifier.rs
+++ b/w3f-ring-vrf-snark/src/piop/verifier.rs
@@ -12,8 +12,8 @@ use w3f_plonk_common::gadgets::fixed_cells::FixedCellsValues;
 use w3f_plonk_common::gadgets::VerifierGadget;
 use w3f_plonk_common::piop::VerifierPiop;
 
-use crate::piop::{FixedColumnsCommitted, RingCommitments};
 use crate::piop::cell_equality::CellEqualityEvals;
+use crate::piop::{FixedColumnsCommitted, RingCommitments};
 use crate::RingEvaluations;
 
 pub struct PiopVerifier<F: PrimeField, C: Commitment<F>, P: AffineRepr<BaseField = F>> {
@@ -105,10 +105,7 @@ impl<F: PrimeField, C: Commitment<F>, P: AffineRepr<BaseField = F>> PiopVerifier
         // pk_index_unique: InnerProd<F>, //TODO:
         let pk_from_index = CondAddValues {
             bitmask: all_columns_evaluated.pk_index,
-            points: (
-                all_columns_evaluated.pks[0],
-                all_columns_evaluated.pks[1],
-            ),
+            points: (all_columns_evaluated.pks[0], all_columns_evaluated.pks[1]),
             not_last: domain_evals.not_last_row,
             acc: (
                 all_columns_evaluated.pk_from_index[0],
@@ -196,9 +193,11 @@ impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> Veri
         let pk_from_index_x = &self.witness_columns_committed.pk_from_index[0];
         let pk_from_index_y = &self.witness_columns_committed.pk_from_index[1];
         let (pk_x_coeff, pk_y_coeff) = self.pk_from_index.acc_coeffs_1();
-        let pk_from_index_c1_lin = pk_from_index_x.mul(pk_x_coeff) + pk_from_index_y.mul(pk_y_coeff);
+        let pk_from_index_c1_lin =
+            pk_from_index_x.mul(pk_x_coeff) + pk_from_index_y.mul(pk_y_coeff);
         let (pk_x_coeff, pk_y_coeff) = self.pk_from_index.acc_coeffs_2();
-        let pk_from_index_c2_lin = pk_from_index_x.mul(pk_x_coeff) + pk_from_index_y.mul(pk_y_coeff);
+        let pk_from_index_c2_lin =
+            pk_from_index_x.mul(pk_x_coeff) + pk_from_index_y.mul(pk_y_coeff);
 
         let per_constraint = vec![
             pk_from_sk_c1_lin,

--- a/w3f-ring-vrf-snark/src/piop/verifier.rs
+++ b/w3f-ring-vrf-snark/src/piop/verifier.rs
@@ -189,12 +189,36 @@ impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> Veri
             self.out_from_in_y.evaluate_constraints_main(),
             self.pks_equal_x.evaluate_constraints_main(),
             self.pks_equal_y.evaluate_constraints_main(),
-            vec![FixedCellsValues::evaluate_for_cell(self.pk_from_sk.acc.0, self.domain_evals.l_first, self.seed.0)],
-            vec![FixedCellsValues::evaluate_for_cell(self.pk_from_sk.acc.1, self.domain_evals.l_first, self.seed.1)],
-            vec![FixedCellsValues::evaluate_for_cell(self.pk_from_index.acc.0, self.domain_evals.l_first, self.seed.0)],
-            vec![FixedCellsValues::evaluate_for_cell(self.pk_from_index.acc.1, self.domain_evals.l_first, self.seed.1)],
-            vec![FixedCellsValues::evaluate_for_cell(self.doublings_of_in_gadget.doublings.0, self.domain_evals.l_first, self.vrf_in.0)],
-            vec![FixedCellsValues::evaluate_for_cell(self.doublings_of_in_gadget.doublings.1, self.domain_evals.l_first, self.vrf_in.1)],
+            vec![FixedCellsValues::evaluate_for_cell(
+                self.pk_from_sk.acc.0,
+                self.domain_evals.l_first,
+                self.seed.0,
+            )],
+            vec![FixedCellsValues::evaluate_for_cell(
+                self.pk_from_sk.acc.1,
+                self.domain_evals.l_first,
+                self.seed.1,
+            )],
+            vec![FixedCellsValues::evaluate_for_cell(
+                self.pk_from_index.acc.0,
+                self.domain_evals.l_first,
+                self.seed.0,
+            )],
+            vec![FixedCellsValues::evaluate_for_cell(
+                self.pk_from_index.acc.1,
+                self.domain_evals.l_first,
+                self.seed.1,
+            )],
+            vec![FixedCellsValues::evaluate_for_cell(
+                self.doublings_of_in_gadget.doublings.0,
+                self.domain_evals.l_first,
+                self.vrf_in.0,
+            )],
+            vec![FixedCellsValues::evaluate_for_cell(
+                self.doublings_of_in_gadget.doublings.1,
+                self.domain_evals.l_first,
+                self.vrf_in.1,
+            )],
         ]
         .concat()
     }
@@ -229,8 +253,8 @@ impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> Veri
         let pk_from_index_c2_lin =
             pk_from_index_x.mul(pk_x_coeff) + pk_from_index_y.mul(pk_y_coeff);
 
-        let pk_index_sum_lin = (&self.witness_columns_committed.pk_index_sum)
-            .mul(self.pk_index_sum.not_last);
+        let pk_index_sum_lin =
+            (&self.witness_columns_committed.pk_index_sum).mul(self.pk_index_sum.not_last);
 
         let per_constraint = vec![
             pk_from_sk_c1_lin,

--- a/w3f-ring-vrf-snark/src/piop/verifier.rs
+++ b/w3f-ring-vrf-snark/src/piop/verifier.rs
@@ -111,7 +111,7 @@ impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> Veri
     for PiopVerifier<F, C, Affine<Jubjub>>
 {
     const N_CONSTRAINTS: usize = 9;
-    const N_COLUMNS: usize = 9;
+    const N_COLUMNS: usize = 12;
 
     fn precommitted_columns(&self) -> Vec<C> {
         self.fixed_columns_committed.as_vec()

--- a/w3f-ring-vrf-snark/src/piop/verifier.rs
+++ b/w3f-ring-vrf-snark/src/piop/verifier.rs
@@ -136,8 +136,8 @@ impl<F: PrimeField, C: Commitment<F>, P: AffineRepr<BaseField = F>> PiopVerifier
 impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> VerifierPiop<F, C>
     for PiopVerifier<F, C, Affine<Jubjub>>
 {
-    const N_CONSTRAINTS: usize = 10;
-    const N_COLUMNS: usize = 12;
+    const N_CONSTRAINTS: usize = 12;
+    const N_COLUMNS: usize = 14;
 
     fn precommitted_columns(&self) -> Vec<C> {
         self.fixed_columns_committed.as_vec()
@@ -146,12 +146,14 @@ impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> Veri
     fn evaluate_constraints_main(&self) -> Vec<F> {
         [
             self.sk_bits_bool.evaluate_constraints_main(),
+            self.pk_index_bool.evaluate_constraints_main(),
             self.pk_from_sk.evaluate_constraints_main(),
             self.doublings_of_in_gadget.evaluate_constraints_main(),
             self.out_from_in.evaluate_constraints_main(),
+            self.pk_from_index_x.evaluate_constraints_main(),
+            self.pk_from_index_y.evaluate_constraints_main(),
             self.out_from_in_x.evaluate_constraints_main(),
             self.out_from_in_y.evaluate_constraints_main(),
-            self.pk_index_bool.evaluate_constraints_main(),
         ]
         .concat()
     }
@@ -177,6 +179,11 @@ impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> Veri
         let (out_x_coeff, out_y_coeff) = self.out_from_in.acc_coeffs_2();
         let out_from_in_c2_lin = out_x.mul(out_x_coeff) + out_y.mul(out_y_coeff);
 
+        let pk_from_index_x = &self.witness_columns_committed.pk_from_index[0];
+        let pk_from_index_y = &self.witness_columns_committed.pk_from_index[1];
+        let pk_from_index_x_lin = pk_from_index_x.mul(self.domain_evals.not_last_row);
+        let pk_from_index_y_lin = pk_from_index_y.mul(self.domain_evals.not_last_row);
+
         vec![
             pk_from_sk_c1_lin,
             pk_from_sk_c2_lin,
@@ -184,6 +191,8 @@ impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> Veri
             doublings_of_in_lin[1].clone(),
             out_from_in_c1_lin,
             out_from_in_c2_lin,
+            pk_from_index_x_lin,
+            pk_from_index_y_lin,
         ]
     }
 

--- a/w3f-ring-vrf-snark/src/ring_vrf_verifier.rs
+++ b/w3f-ring-vrf-snark/src/ring_vrf_verifier.rs
@@ -10,9 +10,9 @@ use w3f_plonk_common::verifier::PlonkVerifier;
 
 use crate::piop::params::PiopParams;
 use crate::piop::{FixedColumnsCommitted, PiopVerifier, VerifierKey};
-use crate::{ArkTranscript, RingProof};
+use crate::{ArkTranscript, RingVrfProof};
 
-pub struct RingVerifier<F, CS, Jubjub, T = ArkTranscript>
+pub struct RingVrfVerifier<F, CS, Jubjub, T = ArkTranscript>
 where
     F: PrimeField,
     CS: PCS<F>,
@@ -24,7 +24,7 @@ where
     plonk_verifier: PlonkVerifier<F, CS, T>,
 }
 
-impl<F, CS, Jubjub, T> RingVerifier<F, CS, Jubjub, T>
+impl<F, CS, Jubjub, T> RingVrfVerifier<F, CS, Jubjub, T>
 where
     F: PrimeField,
     CS: PCS<F>,
@@ -47,9 +47,9 @@ where
 
     pub fn verify(
         &self,
-        proof: RingProof<F, CS>,
         vrf_in: Affine<Jubjub>,
         vrf_out: Affine<Jubjub>,
+        proof: RingVrfProof<F, CS>,
     ) -> bool {
         let (challenges, mut rng) = self.plonk_verifier.restore_challenges(
             &vrf_out,
@@ -60,14 +60,14 @@ where
         );
         let seed = self.piop_params.seed;
         let seed_plus_out = (seed + vrf_out).into_affine();
-        let domain_eval = EvaluatedDomain::new(
+        let domain_evals = EvaluatedDomain::new(
             self.piop_params.domain.domain(),
             challenges.zeta,
             self.piop_params.domain.hiding,
         );
 
         let piop = PiopVerifier::<_, _, Affine<Jubjub>>::init(
-            domain_eval,
+            domain_evals,
             self.fixed_columns_committed.clone(),
             proof.column_commitments.clone(),
             proof.columns_at_zeta.clone(),


### PR DESCRIPTION
To check that the signer belongs to the ring we:
1. compute pk1 = sk.G
2. witness the index of the signer k=(0,...,0,1,0,...,0) and compute pk2 = <k, pks>
3. check the equality between pk1 == pk2