### PR TITLE
subgroup check

### DIFF
--- a/w3f-plonk-common/src/kzg_acc.rs
+++ b/w3f-plonk-common/src/kzg_acc.rs
@@ -134,10 +134,16 @@ impl<E: Pairing> KzgAccumulator<E> {
     }
 
     pub fn verify(&self) -> bool {
-        let acc = (-E::G1::msm(&self.acc_points, &self.acc_scalars).unwrap()).into_affine();
         let proof = E::G1::msm(&self.kzg_proofs, &self.randomizers)
             .unwrap()
             .into_affine();
+        if !crate::is_in_correct_subgroup_assuming_on_curve::<E>(&proof) {
+            return false;
+        }
+        let acc = (-E::G1::msm(&self.acc_points, &self.acc_scalars).unwrap()).into_affine();
+        if !crate::is_in_correct_subgroup_assuming_on_curve::<E>(&acc) {
+            return false;
+        }
         KZG::<E>::verify_accumulated(AccumulatedOpening { acc, proof }, &self.kzg_vk)
     }
 }

--- a/w3f-plonk-common/src/lib.rs
+++ b/w3f-plonk-common/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use ark_ff::{FftField, PrimeField};
+use ark_ec::pairing::Pairing;
+use ark_ec::AffineRepr;
+use ark_ff::{FftField, Field, PrimeField, Zero};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::{EvaluationDomain, Evaluations, GeneralEvaluationDomain, Polynomial};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -76,6 +78,12 @@ pub trait ColumnsCommited<F: PrimeField, C: Commitment<F>>:
     CanonicalSerialize + CanonicalDeserialize
 {
     fn to_vec(self) -> Vec<C>;
+}
+
+// suboptimal for BLS12-381
+fn is_in_correct_subgroup_assuming_on_curve<E: Pairing>(p: &E::G1Affine) -> bool {
+    let r = E::ScalarField::characteristic();
+    p.mul_bigint(r).is_zero()
 }
 
 #[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]


### PR DESCRIPTION
Now the 2 points (the aggregated proof and the accumulator) that go into the pairing are subgroup checked. Then may be the points in the proofs don't have to be checked at the deserialization. I've never seen a proof of that. @AlistairStewart had a hackmd on that that i didn't find comprehensible.

I would also do the same for a standalone proof for consistency, but couldn't as it doesn't really make sense in the abstract setting.

> // ··End:     Verify Batch KZG ........................................................1.444ms -- base 1
    // ··End:     Verify Batch KZG ........................................................1.753ms -- check 1
    // ··End:     Verify Batch KZG ........................................................4.382ms -- base 10
    // ··End:     Verify Batch KZG ........................................................4.614ms -- check 10

So ~0.15 ms per a multiplication by the scalar field size. If we specialize to bls12-381 that would be may be 2x better due to the endomorphism.