### PR TITLE
Back to sw

### DIFF
--- a/w3f-ring-proof/benches/ring_proof.rs
+++ b/w3f-ring-proof/benches/ring_proof.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criteri
 
 use ark_bls12_381::Bls12_381;
 use ark_ec::CurveGroup;
-use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, SWAffine, Fq, Fr};
+use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, Fq, Fr, SWAffine};
 use ark_serialize::CanonicalSerialize;
 use ark_std::ops::Mul;
 use ark_std::rand::Rng;

--- a/w3f-ring-proof/benches/ring_proof.rs
+++ b/w3f-ring-proof/benches/ring_proof.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criteri
 
 use ark_bls12_381::Bls12_381;
 use ark_ec::CurveGroup;
-use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, EdwardsAffine, Fq, Fr};
+use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, SWAffine, Fq, Fr};
 use ark_serialize::CanonicalSerialize;
 use ark_std::ops::Mul;
 use ark_std::rand::Rng;
@@ -25,9 +25,9 @@ fn setup(
     let setup_degree = 3 * domain_size;
     let pcs_params = CS::setup(setup_degree, rng);
     let domain = Domain::new(domain_size, true);
-    let h = EdwardsAffine::rand(rng);
-    let seed = EdwardsAffine::rand(rng);
-    let padding = EdwardsAffine::rand(rng);
+    let h = SWAffine::rand(rng);
+    let seed = SWAffine::rand(rng);
+    let padding = SWAffine::rand(rng);
     let piop_params = PiopParams::setup(domain, h, seed, padding);
     (pcs_params, piop_params)
 }
@@ -37,7 +37,7 @@ fn make_transcript() -> ArkTranscript {
 }
 
 /// Get the Pedersen blinding base H from the PIOP params (first element of the power-of-2 multiples).
-fn get_h(piop_params: &PiopParams<Fq, BandersnatchConfig>) -> EdwardsAffine {
+fn get_h(piop_params: &PiopParams<Fq, BandersnatchConfig>) -> SWAffine {
     piop_params.power_of_2_multiples_of_h()[0]
 }
 
@@ -45,9 +45,9 @@ fn get_h(piop_params: &PiopParams<Fq, BandersnatchConfig>) -> EdwardsAffine {
 fn generate_proof(
     piop_params: &PiopParams<Fq, BandersnatchConfig>,
     pcs_params: &<CS as PCS<Fq>>::Params,
-    pks: &[EdwardsAffine],
+    pks: &[SWAffine],
     rng: &mut impl Rng,
-) -> (EdwardsAffine, RingProof<Fq, CS>) {
+) -> (SWAffine, RingProof<Fq, CS>) {
     let h = get_h(piop_params);
     let prover_idx = rng.gen_range(0..pks.len());
     let (prover_key, _) = index::<_, CS, _>(pcs_params, piop_params, pks);
@@ -86,7 +86,7 @@ fn bench_index(c: &mut Criterion) {
         let n = 1usize << log_n;
         let (pcs_params, piop_params) = setup(rng, n);
         let keyset_size = piop_params.keyset_part_size;
-        let pks = random_vec::<EdwardsAffine, _>(keyset_size, rng);
+        let pks = random_vec::<SWAffine, _>(keyset_size, rng);
 
         group.bench_with_input(BenchmarkId::new("full_keyset", n), &n, |b, _| {
             b.iter(|| index::<_, CS, _>(&pcs_params, &piop_params, &pks));
@@ -104,7 +104,7 @@ fn bench_prove(c: &mut Criterion) {
         let n = 1usize << log_n;
         let (pcs_params, piop_params) = setup(rng, n);
         let keyset_size = piop_params.keyset_part_size;
-        let pks = random_vec::<EdwardsAffine, _>(keyset_size, rng);
+        let pks = random_vec::<SWAffine, _>(keyset_size, rng);
         let (prover_key, _) = index::<_, CS, _>(&pcs_params, &piop_params, &pks);
 
         let prover_idx = rng.gen_range(0..keyset_size);
@@ -132,7 +132,7 @@ fn bench_verify(c: &mut Criterion) {
         let n = 1usize << log_n;
         let (pcs_params, piop_params) = setup(rng, n);
         let keyset_size = piop_params.keyset_part_size;
-        let pks = random_vec::<EdwardsAffine, _>(keyset_size, rng);
+        let pks = random_vec::<SWAffine, _>(keyset_size, rng);
 
         let (blinded_pk, proof) = generate_proof(&piop_params, &pcs_params, &pks, rng);
         let (_, verifier_key) = index::<_, CS, _>(&pcs_params, &piop_params, &pks);
@@ -154,11 +154,11 @@ fn bench_verify_batch_sequential(c: &mut Criterion) {
     let n = 1usize << log_n;
     let (pcs_params, piop_params) = setup(rng, n);
     let keyset_size = piop_params.keyset_part_size;
-    let pks = random_vec::<EdwardsAffine, _>(keyset_size, rng);
+    let pks = random_vec::<SWAffine, _>(keyset_size, rng);
 
     // Pre-generate proofs for the largest batch.
     let max_batch = 32;
-    let claims: Vec<(EdwardsAffine, RingProof<Fq, CS>)> = (0..max_batch)
+    let claims: Vec<(SWAffine, RingProof<Fq, CS>)> = (0..max_batch)
         .map(|_| generate_proof(&piop_params, &pcs_params, &pks, rng))
         .collect();
 
@@ -188,10 +188,10 @@ fn bench_verify_batch_kzg(c: &mut Criterion) {
     let n = 1usize << log_n;
     let (pcs_params, piop_params) = setup(rng, n);
     let keyset_size = piop_params.keyset_part_size;
-    let pks = random_vec::<EdwardsAffine, _>(keyset_size, rng);
+    let pks = random_vec::<SWAffine, _>(keyset_size, rng);
 
     let max_batch = 32;
-    let claims: Vec<(EdwardsAffine, RingProof<Fq, CS>)> = (0..max_batch)
+    let claims: Vec<(SWAffine, RingProof<Fq, CS>)> = (0..max_batch)
         .map(|_| generate_proof(&piop_params, &pcs_params, &pks, rng))
         .collect();
 
@@ -227,7 +227,7 @@ fn bench_proof_size(c: &mut Criterion) {
     let n = 1usize << 10;
     let (pcs_params, piop_params) = setup(rng, n);
     let keyset_size = piop_params.keyset_part_size;
-    let pks = random_vec::<EdwardsAffine, _>(keyset_size, rng);
+    let pks = random_vec::<SWAffine, _>(keyset_size, rng);
 
     let (_, proof) = generate_proof(&piop_params, &pcs_params, &pks, rng);
 

--- a/w3f-ring-proof/src/lib.rs
+++ b/w3f-ring-proof/src/lib.rs
@@ -53,7 +53,7 @@ impl ArkTranscript {
 mod tests {
     use ark_bls12_381::Bls12_381;
     use ark_ec::CurveGroup;
-    use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, SWAffine, Fq, Fr};
+    use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, Fq, Fr, SWAffine};
     use ark_std::ops::Mul;
     use ark_std::rand::Rng;
     use ark_std::{end_timer, start_timer, test_rng, UniformRand};

--- a/w3f-ring-proof/src/lib.rs
+++ b/w3f-ring-proof/src/lib.rs
@@ -53,7 +53,7 @@ impl ArkTranscript {
 mod tests {
     use ark_bls12_381::Bls12_381;
     use ark_ec::CurveGroup;
-    use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, EdwardsAffine, Fq, Fr};
+    use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, SWAffine, Fq, Fr};
     use ark_std::ops::Mul;
     use ark_std::rand::Rng;
     use ark_std::{end_timer, start_timer, test_rng, UniformRand};
@@ -73,17 +73,17 @@ mod tests {
         batch_size: usize,
     ) -> (
         RingVerifier<Fq, CS, BandersnatchConfig>,
-        Vec<(EdwardsAffine, RingProof<Fq, CS>)>,
+        Vec<(SWAffine, RingProof<Fq, CS>)>,
     ) {
         let rng = &mut test_rng();
 
         let (pcs_params, piop_params) = setup::<_, CS>(rng, domain_size);
         let keyset_size = piop_params.keyset_part_size;
-        let pks = random_vec::<EdwardsAffine, _>(keyset_size, rng);
+        let pks = random_vec::<SWAffine, _>(keyset_size, rng);
         let (prover_key, verifier_key) = index::<_, CS, _>(&pcs_params, &piop_params, &pks);
 
         let t_prove = start_timer!(|| "Prove");
-        let claims: Vec<(EdwardsAffine, RingProof<Fq, CS>)> = (0..batch_size)
+        let claims: Vec<(SWAffine, RingProof<Fq, CS>)> = (0..batch_size)
             .map(|_| {
                 let prover_idx = rng.gen_range(0..keyset_size);
                 let prover = RingProver::init(
@@ -125,7 +125,7 @@ mod tests {
 
         let max_keyset_size = piop_params.keyset_part_size;
         let keyset_size: usize = rng.gen_range(0..max_keyset_size);
-        let pks = random_vec::<EdwardsAffine, _>(keyset_size, rng);
+        let pks = random_vec::<SWAffine, _>(keyset_size, rng);
 
         let (_, verifier_key) = index::<_, KZG<Bls12_381>, _>(&pcs_params, &piop_params, &pks);
 
@@ -146,9 +146,9 @@ mod tests {
         let pcs_params = CS::setup(setup_degree, rng);
 
         let domain = Domain::new(domain_size, true);
-        let h = EdwardsAffine::rand(rng);
-        let seed = EdwardsAffine::rand(rng);
-        let padding = EdwardsAffine::rand(rng);
+        let h = SWAffine::rand(rng);
+        let seed = SWAffine::rand(rng);
+        let padding = SWAffine::rand(rng);
         let piop_params = PiopParams::setup(domain, h, seed, padding);
 
         (pcs_params, piop_params)
@@ -197,18 +197,18 @@ mod tests {
 
         // Ring A
         let keyset_size_a = piop_params.keyset_part_size;
-        let pks_a = random_vec::<EdwardsAffine, _>(keyset_size_a, rng);
+        let pks_a = random_vec::<SWAffine, _>(keyset_size_a, rng);
         let (prover_key_a, verifier_key_a) =
             index::<_, KZG<Bls12_381>, _>(&pcs_params, &piop_params, &pks_a);
 
         // Ring B (smaller keyset)
         let keyset_size_b = piop_params.keyset_part_size / 2;
-        let pks_b = random_vec::<EdwardsAffine, _>(keyset_size_b, rng);
+        let pks_b = random_vec::<SWAffine, _>(keyset_size_b, rng);
         let (prover_key_b, verifier_key_b) =
             index::<_, KZG<Bls12_381>, _>(&pcs_params, &piop_params, &pks_b);
 
-        let mut generate_claims = |prover_key: &ProverKey<Fq, KZG<Bls12_381>, EdwardsAffine>,
-                                   pks: &[EdwardsAffine],
+        let mut generate_claims = |prover_key: &ProverKey<Fq, KZG<Bls12_381>, SWAffine>,
+                                   pks: &[SWAffine],
                                    keyset_size: usize| {
             (0..proofs_per_ring)
                 .map(|_| {

--- a/w3f-ring-proof/src/multi_ring_batch_verifier.rs
+++ b/w3f-ring-proof/src/multi_ring_batch_verifier.rs
@@ -1,5 +1,5 @@
 use ark_ec::pairing::Pairing;
-use ark_ec::twisted_edwards::{Affine, TECurveConfig};
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ec::CurveGroup;
 use ark_std::rand::RngCore;
 use w3f_pcs::pcs::kzg::params::KzgVerifierKey;
@@ -21,7 +21,7 @@ use crate::RingProof;
 pub struct PreparedMultiRingItem<'a, E, J, T>
 where
     E: Pairing,
-    J: TECurveConfig<BaseField = E::ScalarField>,
+    J: SWCurveConfig<BaseField = E::ScalarField>,
     T: PlonkTranscript<E::ScalarField, KZG<E>>,
 {
     verifier: &'a RingVerifier<E::ScalarField, KZG<E>, J, T>,
@@ -61,7 +61,7 @@ impl<E: Pairing> MultiRingBatchVerifier<E> {
         result: Affine<J>,
     ) -> PreparedMultiRingItem<'a, E, J, T>
     where
-        J: TECurveConfig<BaseField = E::ScalarField>,
+        J: SWCurveConfig<BaseField = E::ScalarField>,
         T: PlonkTranscript<E::ScalarField, KZG<E>>,
     {
         let (challenges, mut rng) = verifier.plonk_verifier.restore_challenges(
@@ -101,7 +101,7 @@ impl<E: Pairing> MultiRingBatchVerifier<E> {
     /// 2. `push_prepared` - must be called sequentially (mutates the accumulator)
     pub fn push_prepared<J, T>(&mut self, item: PreparedMultiRingItem<'_, E, J, T>)
     where
-        J: TECurveConfig<BaseField = E::ScalarField>,
+        J: SWCurveConfig<BaseField = E::ScalarField>,
         T: PlonkTranscript<E::ScalarField, KZG<E>>,
     {
         let mut ts = item.verifier.plonk_verifier.transcript_prelude.clone();
@@ -117,7 +117,7 @@ impl<E: Pairing> MultiRingBatchVerifier<E> {
         proof: RingProof<E::ScalarField, KZG<E>>,
         result: Affine<J>,
     ) where
-        J: TECurveConfig<BaseField = E::ScalarField>,
+        J: SWCurveConfig<BaseField = E::ScalarField>,
         T: PlonkTranscript<E::ScalarField, KZG<E>>,
     {
         let item = Self::prepare(verifier, proof, result);

--- a/w3f-ring-proof/src/piop/mod.rs
+++ b/w3f-ring-proof/src/piop/mod.rs
@@ -1,5 +1,5 @@
 use ark_ec::pairing::Pairing;
-use ark_ec::twisted_edwards::{Affine, TECurveConfig};
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ec::AffineRepr;
 use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -97,7 +97,7 @@ impl<F: PrimeField, C: Commitment<F>> FixedColumnsCommitted<F, C> {
 }
 
 impl<E: Pairing> FixedColumnsCommitted<E::ScalarField, KzgCommitment<E>> {
-    pub fn from_ring<G: TECurveConfig<BaseField = E::ScalarField>>(
+    pub fn from_ring<G: SWCurveConfig<BaseField = E::ScalarField>>(
         ring: &Ring<E::ScalarField, E, G>,
     ) -> Self {
         let cx = KzgCommitment(ring.cx);
@@ -159,7 +159,7 @@ impl<F: PrimeField, CS: PCS<F>> Clone for VerifierKey<F, CS> {
 }
 
 impl<E: Pairing> VerifierKey<E::ScalarField, KZG<E>> {
-    pub fn from_ring_and_kzg_vk<G: TECurveConfig<BaseField = E::ScalarField>>(
+    pub fn from_ring_and_kzg_vk<G: SWCurveConfig<BaseField = E::ScalarField>>(
         ring: &Ring<E::ScalarField, E, G>,
         kzg_vk: RawKzgVerifierKey<E>,
     ) -> Self {
@@ -181,7 +181,7 @@ impl<E: Pairing> VerifierKey<E::ScalarField, KZG<E>> {
     }
 }
 
-pub fn index<F: PrimeField, CS: PCS<F>, Curve: TECurveConfig<BaseField = F>>(
+pub fn index<F: PrimeField, CS: PCS<F>, Curve: SWCurveConfig<BaseField = F>>(
     pcs_params: &CS::Params,
     piop_params: &PiopParams<F, Curve>,
     keys: &[Affine<Curve>],

--- a/w3f-ring-proof/src/piop/params.rs
+++ b/w3f-ring-proof/src/piop/params.rs
@@ -1,4 +1,4 @@
-use ark_ec::twisted_edwards::{Affine, TECurveConfig};
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ec::{AdditiveGroup, AffineRepr, CurveGroup};
 use ark_ff::{BigInteger, PrimeField};
 use ark_std::{vec, vec::Vec};
@@ -10,7 +10,7 @@ use crate::piop::FixedColumns;
 
 /// Plonk Interactive Oracle Proofs (PIOP) parameters.
 #[derive(Clone)]
-pub struct PiopParams<F: PrimeField, Curve: TECurveConfig<BaseField = F>> {
+pub struct PiopParams<F: PrimeField, Curve: SWCurveConfig<BaseField = F>> {
     /// Domain over which the piop is represented.
     pub(crate) domain: Domain<F>,
     /// Number of bits used to represent a jubjub scalar.
@@ -25,7 +25,7 @@ pub struct PiopParams<F: PrimeField, Curve: TECurveConfig<BaseField = F>> {
     pub(crate) padding: Affine<Curve>,
 }
 
-impl<F: PrimeField, Curve: TECurveConfig<BaseField = F>> PiopParams<F, Curve> {
+impl<F: PrimeField, Curve: SWCurveConfig<BaseField = F>> PiopParams<F, Curve> {
     /// Initialize PIOP parameters.
     ///
     /// - `domain`: polynomials evaluation domain.
@@ -100,9 +100,9 @@ impl<F: PrimeField, Curve: TECurveConfig<BaseField = F>> PiopParams<F, Curve> {
 
 #[cfg(test)]
 mod tests {
-    use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, EdwardsAffine, Fq, Fr};
-    use ark_std::ops::Mul;
+    use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, SWAffine, Fq, Fr};
     use ark_std::{test_rng, UniformRand};
+    use ark_std::ops::Mul;
 
     use w3f_plonk_common::domain::Domain;
     use w3f_plonk_common::test_helpers::cond_sum;
@@ -112,9 +112,9 @@ mod tests {
     #[test]
     fn test_powers_of_h() {
         let rng = &mut test_rng();
-        let h = EdwardsAffine::rand(rng);
-        let seed = EdwardsAffine::rand(rng);
-        let padding = EdwardsAffine::rand(rng);
+        let h = SWAffine::rand(rng);
+        let seed = SWAffine::rand(rng);
+        let padding = SWAffine::rand(rng);
         let domain = Domain::new(1024, false);
 
         let params = PiopParams::<Fq, BandersnatchConfig>::setup(domain, h, seed, padding);

--- a/w3f-ring-proof/src/piop/params.rs
+++ b/w3f-ring-proof/src/piop/params.rs
@@ -100,9 +100,9 @@ impl<F: PrimeField, Curve: SWCurveConfig<BaseField = F>> PiopParams<F, Curve> {
 
 #[cfg(test)]
 mod tests {
-    use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, SWAffine, Fq, Fr};
-    use ark_std::{test_rng, UniformRand};
+    use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, Fq, Fr, SWAffine};
     use ark_std::ops::Mul;
+    use ark_std::{test_rng, UniformRand};
 
     use w3f_plonk_common::domain::Domain;
     use w3f_plonk_common::test_helpers::cond_sum;

--- a/w3f-ring-proof/src/piop/prover.rs
+++ b/w3f-ring-proof/src/piop/prover.rs
@@ -1,4 +1,4 @@
-use ark_ec::twisted_edwards::{Affine, TECurveConfig};
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::PrimeField;
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::Evaluations;
@@ -22,7 +22,7 @@ use w3f_plonk_common::{Column, FieldColumn};
 
 // The 'table': columns representing the execution trace of the computation
 // and the constraints -- polynomials that vanish on every 2 consecutive rows.
-pub struct PiopProver<F: PrimeField, Curve: TECurveConfig<BaseField = F>> {
+pub struct PiopProver<F: PrimeField, Curve: SWCurveConfig<BaseField = F>> {
     domain: Domain<F>,
     /// Advice (public input) columns
     points: AffineColumn<F, Affine<Curve>>,
@@ -38,7 +38,7 @@ pub struct PiopProver<F: PrimeField, Curve: TECurveConfig<BaseField = F>> {
     cond_add_acc_y: FixedCells<F>,
 }
 
-impl<F: PrimeField, Curve: TECurveConfig<BaseField = F>> PiopProver<F, Curve> {
+impl<F: PrimeField, Curve: SWCurveConfig<BaseField = F>> PiopProver<F, Curve> {
     pub fn build(
         params: &PiopParams<F, Curve>,
         fixed_columns: FixedColumns<F, Affine<Curve>>,
@@ -90,7 +90,7 @@ impl<F, C, Curve> ProverPiop<F, C> for PiopProver<F, Curve>
 where
     F: PrimeField,
     C: Commitment<F>,
-    Curve: TECurveConfig<BaseField = F>,
+    Curve: SWCurveConfig<BaseField = F>,
 {
     type Commitments = RingCommitments<F, C>;
     type Evaluations = RingEvaluations<F>;

--- a/w3f-ring-proof/src/piop/verifier.rs
+++ b/w3f-ring-proof/src/piop/verifier.rs
@@ -1,4 +1,4 @@
-use ark_ec::twisted_edwards::{Affine, TECurveConfig};
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ec::AffineRepr;
 use ark_ff::PrimeField;
 use ark_std::marker::PhantomData;
@@ -101,7 +101,7 @@ impl<F: PrimeField, C: Commitment<F>, P: AffineRepr<BaseField = F>> PiopVerifier
     }
 }
 
-impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> VerifierPiop<F, C>
+impl<F: PrimeField, C: Commitment<F>, Jubjub: SWCurveConfig<BaseField = F>> VerifierPiop<F, C>
     for PiopVerifier<F, C, Affine<Jubjub>>
 {
     const N_CONSTRAINTS: usize = 7;

--- a/w3f-ring-proof/src/ring.rs
+++ b/w3f-ring-proof/src/ring.rs
@@ -1,5 +1,5 @@
 use ark_ec::pairing::Pairing;
-use ark_ec::twisted_edwards::{Affine, TECurveConfig};
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ec::{AffineRepr, CurveGroup, VariableBaseMSM};
 use ark_ff::PrimeField;
 use ark_poly::EvaluationDomain;
@@ -36,7 +36,7 @@ const IDLE_ROWS: usize = ZK_ROWS + 1;
 pub struct Ring<
     F: PrimeField,
     KzgCurve: Pairing<ScalarField = F>,
-    VrfCurveConfig: TECurveConfig<BaseField = F>,
+    VrfCurveConfig: SWCurveConfig<BaseField = F>,
 > {
     /// KZG commitment to the x coordinates of the described vector.
     pub cx: KzgCurve::G1Affine,
@@ -55,7 +55,7 @@ pub struct Ring<
 impl<
         F: PrimeField,
         KzgCurve: Pairing<ScalarField = F>,
-        VrfCurveConfig: TECurveConfig<BaseField = F>,
+        VrfCurveConfig: SWCurveConfig<BaseField = F>,
     > fmt::Debug for Ring<F, KzgCurve, VrfCurveConfig>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -70,7 +70,7 @@ impl<
 impl<
         F: PrimeField,
         KzgCurve: Pairing<ScalarField = F>,
-        VrfCurveConfig: TECurveConfig<BaseField = F>,
+        VrfCurveConfig: SWCurveConfig<BaseField = F>,
     > Ring<F, KzgCurve, VrfCurveConfig>
 {
     /// Builds the commitment to the vector
@@ -257,7 +257,7 @@ impl<F: PrimeField, KzgCurve: Pairing<ScalarField = F>> RingBuilderKey<F, KzgCur
 #[cfg(test)]
 mod tests {
     use ark_bls12_381::{Bls12_381, Fr, G1Affine};
-    use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, EdwardsAffine};
+    use ark_ed_on_bls12_381_bandersnatch::{BandersnatchConfig, SWAffine};
     use ark_std::{test_rng, UniformRand};
     use w3f_pcs::pcs::kzg::urs::URS;
     use w3f_pcs::pcs::kzg::KZG;
@@ -284,9 +284,9 @@ mod tests {
         let srs = |range: Range<usize>| Ok(ring_builder_key.lis_in_g1[range].to_vec());
 
         // piop params
-        let h = EdwardsAffine::rand(rng);
-        let seed = EdwardsAffine::rand(rng);
-        let padding = EdwardsAffine::rand(rng);
+        let h = SWAffine::rand(rng);
+        let seed = SWAffine::rand(rng);
+        let padding = SWAffine::rand(rng);
         let domain = Domain::new(domain_size, true);
         let piop_params = PiopParams::setup(domain, h, seed, padding);
 
@@ -295,7 +295,7 @@ mod tests {
         assert_eq!(ring.cx, monimial_cx);
         assert_eq!(ring.cy, monimial_cy);
 
-        let keys = random_vec::<EdwardsAffine, _>(ring.max_keys, rng);
+        let keys = random_vec::<SWAffine, _>(ring.max_keys, rng);
         ring.append(&keys, srs);
         let (monimial_cx, monimial_cy) = get_monomial_commitment(&pcs_params, &piop_params, &keys);
         assert_eq!(ring.cx, monimial_cx);
@@ -316,9 +316,9 @@ mod tests {
         let srs = |range: Range<usize>| Ok(ring_builder_key.lis_in_g1[range].to_vec());
 
         // piop params
-        let h = EdwardsAffine::rand(rng);
-        let seed = EdwardsAffine::rand(rng);
-        let padding = EdwardsAffine::rand(rng);
+        let h = SWAffine::rand(rng);
+        let seed = SWAffine::rand(rng);
+        let padding = SWAffine::rand(rng);
         let domain = Domain::new(domain_size, true);
         let piop_params = PiopParams::setup(domain, h, seed, padding);
 
@@ -330,7 +330,7 @@ mod tests {
     fn get_monomial_commitment(
         pcs_params: &URS<Bls12_381>,
         piop_params: &PiopParams<Fr, BandersnatchConfig>,
-        keys: &[EdwardsAffine],
+        keys: &[SWAffine],
     ) -> (G1Affine, G1Affine) {
         let (_, verifier_key) =
             crate::piop::index::<_, KZG<Bls12_381>, _>(pcs_params, piop_params, keys);

--- a/w3f-ring-proof/src/ring_prover.rs
+++ b/w3f-ring-proof/src/ring_prover.rs
@@ -1,4 +1,4 @@
-use ark_ec::twisted_edwards::{Affine, TECurveConfig};
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::PrimeField;
 use ark_std::{end_timer, start_timer};
 use w3f_pcs::pcs::PCS;
@@ -14,7 +14,7 @@ pub struct RingProver<F, CS, Curve, T = ArkTranscript>
 where
     F: PrimeField,
     CS: PCS<F>,
-    Curve: TECurveConfig<BaseField = F>,
+    Curve: SWCurveConfig<BaseField = F>,
     T: PlonkTranscript<F, CS>,
 {
     piop_params: PiopParams<F, Curve>,
@@ -27,7 +27,7 @@ impl<F, CS, Curve, T> RingProver<F, CS, Curve, T>
 where
     F: PrimeField,
     CS: PCS<F>,
-    Curve: TECurveConfig<BaseField = F>,
+    Curve: SWCurveConfig<BaseField = F>,
     T: PlonkTranscript<F, CS>,
 {
     pub fn init(

--- a/w3f-ring-proof/src/ring_verifier.rs
+++ b/w3f-ring-proof/src/ring_verifier.rs
@@ -1,5 +1,5 @@
 use ark_ec::pairing::Pairing;
-use ark_ec::twisted_edwards::{Affine, TECurveConfig};
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_std::rand::RngCore;
@@ -19,7 +19,7 @@ pub struct RingVerifier<F, CS, Jubjub, T = ArkTranscript>
 where
     F: PrimeField,
     CS: PCS<F>,
-    Jubjub: TECurveConfig<BaseField = F>,
+    Jubjub: SWCurveConfig<BaseField = F>,
     T: PlonkTranscript<F, CS>,
 {
     pub(crate) piop_params: PiopParams<F, Jubjub>,
@@ -31,7 +31,7 @@ impl<F, CS, Jubjub, T> RingVerifier<F, CS, Jubjub, T>
 where
     F: PrimeField,
     CS: PCS<F>,
-    Jubjub: TECurveConfig<BaseField = F>,
+    Jubjub: SWCurveConfig<BaseField = F>,
     T: PlonkTranscript<F, CS>,
 {
     pub fn init(
@@ -99,7 +99,7 @@ where
 pub struct KzgBatchVerifier<E, J, T = ArkTranscript>
 where
     E: Pairing,
-    J: TECurveConfig<BaseField = E::ScalarField>,
+    J: SWCurveConfig<BaseField = E::ScalarField>,
     T: PlonkTranscript<E::ScalarField, KZG<E>>,
 {
     pub acc: KzgAccumulator<E>,
@@ -110,7 +110,7 @@ where
 pub struct PreparedBatchItem<E, J>
 where
     E: Pairing,
-    J: TECurveConfig<BaseField = E::ScalarField>,
+    J: SWCurveConfig<BaseField = E::ScalarField>,
 {
     piop: PiopVerifier<E::ScalarField, <KZG<E> as PCS<E::ScalarField>>::C, Affine<J>>,
     proof: RingProof<E::ScalarField, KZG<E>>,
@@ -121,7 +121,7 @@ where
 impl<E, J, T> KzgBatchVerifier<E, J, T>
 where
     E: Pairing,
-    J: TECurveConfig<BaseField = E::ScalarField>,
+    J: SWCurveConfig<BaseField = E::ScalarField>,
     T: PlonkTranscript<E::ScalarField, KZG<E>>,
 {
     /// Prepares a ring proof for batch verification without accumulating it.
@@ -200,7 +200,7 @@ where
 impl<E, J, T> RingVerifier<E::ScalarField, KZG<E>, J, T>
 where
     E: Pairing,
-    J: TECurveConfig<BaseField = E::ScalarField>,
+    J: SWCurveConfig<BaseField = E::ScalarField>,
     T: PlonkTranscript<E::ScalarField, KZG<E>>,
 {
     /// Build a new batch verifier.


### PR DESCRIPTION
Pasta curves don't have edwards form, so I found and replaced:

use ark_ec::twisted_edwards::{Affine, TECurveConfig};
-> use ark_ec::short_weierstrass::{Affine, SWCurveConfig};

TECurveConfig -> SWCurveConfig

ark_ed_on_bls12_381_bandersnatch::EdwardsAffine
-> ark_ed_on_bls12_381_bandersnatch::SWAffine

The question is. Do we have to restore the TE implementation fr bandersnatch? I would assume that our proofs are short-lived, so we can upgrade carefully?