### PR TITLE
Remove single ring batch verifier

### DIFF
--- a/w3f-ring-proof/Cargo.toml
+++ b/w3f-ring-proof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "w3f-ring-proof"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 authors = ["Sergey Vasilyev <swasilyev@gmail.com>"]
 license = "MIT/Apache-2.0"

--- a/w3f-ring-proof/benches/ring_proof.rs
+++ b/w3f-ring-proof/benches/ring_proof.rs
@@ -195,6 +195,9 @@ fn bench_verify_batch_kzg(c: &mut Criterion) {
         .map(|_| generate_proof(&piop_params, &pcs_params, &pks, rng))
         .collect();
 
+    let (_, verifier_key) = index::<_, CS, _>(&pcs_params, &piop_params, &pks);
+    let verifier = RingVerifier::init(verifier_key, piop_params, make_transcript());
+
     for batch_size in [1, 4, 16, 32] {
         let (results, proofs): (Vec<_>, Vec<_>) = claims[..batch_size].iter().cloned().unzip();
 
@@ -202,15 +205,9 @@ fn bench_verify_batch_kzg(c: &mut Criterion) {
             BenchmarkId::new("kzg_accumulator", batch_size),
             &batch_size,
             |b, _| {
-                // Recreate verifier each iteration since verify_batch_kzg consumes self.
                 b.iter_batched(
-                    || {
-                        let (_, vk) = index::<_, CS, _>(&pcs_params, &piop_params, &pks);
-                        let verifier =
-                            RingVerifier::init(vk, piop_params.clone(), make_transcript());
-                        (verifier, proofs.clone(), results.clone())
-                    },
-                    |(verifier, proofs, results)| verifier.verify_batch_kzg(proofs, results),
+                    || (proofs.clone(), results.clone()),
+                    |(proofs, results)| verifier.verify_batch_kzg(proofs, results),
                     BatchSize::LargeInput,
                 );
             },

--- a/w3f-ring-proof/src/lib.rs
+++ b/w3f-ring-proof/src/lib.rs
@@ -267,10 +267,10 @@ mod tests {
             verifier_a.plonk_verifier.transcript_prelude.clone(),
         );
         for (result, proof) in claims_a {
-            batch.push(&verifier_a, proof, result);
+            batch.push_raw(&verifier_a, proof, result);
         }
         for (result, proof) in claims_b {
-            batch.push(&verifier_b, proof, result);
+            batch.push_raw(&verifier_b, proof, result);
         }
         assert!(batch.verify());
     }

--- a/w3f-ring-proof/src/lib.rs
+++ b/w3f-ring-proof/src/lib.rs
@@ -261,8 +261,8 @@ mod tests {
         }
 
         // Multi-ring batch verification
-        use crate::multi_ring_batch_verifier::MultiRingBatchVerifier;
-        let mut batch = MultiRingBatchVerifier::new(
+        use crate::multi_ring_batch_verifier::BatchVerifier;
+        let mut batch = BatchVerifier::new(
             verifier_a.pcs_vk().clone(),
             verifier_a.plonk_verifier.transcript_prelude.clone(),
         );

--- a/w3f-ring-proof/src/lib.rs
+++ b/w3f-ring-proof/src/lib.rs
@@ -262,7 +262,10 @@ mod tests {
 
         // Multi-ring batch verification
         use crate::multi_ring_batch_verifier::MultiRingBatchVerifier;
-        let mut batch = MultiRingBatchVerifier::new(verifier_a.pcs_vk().clone());
+        let mut batch = MultiRingBatchVerifier::new(
+            verifier_a.pcs_vk().clone(),
+            verifier_a.plonk_verifier.transcript_prelude.clone(),
+        );
         for (result, proof) in claims_a {
             batch.push(&verifier_a, proof, result);
         }

--- a/w3f-ring-proof/src/lib.rs
+++ b/w3f-ring-proof/src/lib.rs
@@ -267,10 +267,10 @@ mod tests {
             verifier_a.plonk_verifier.transcript_prelude.clone(),
         );
         for (result, proof) in claims_a {
-            batch.push_raw(&verifier_a, proof, result);
+            batch.push(&verifier_a, proof, result);
         }
         for (result, proof) in claims_b {
-            batch.push_raw(&verifier_b, proof, result);
+            batch.push(&verifier_b, proof, result);
         }
         assert!(batch.verify());
     }

--- a/w3f-ring-proof/src/multi_ring_batch_verifier.rs
+++ b/w3f-ring-proof/src/multi_ring_batch_verifier.rs
@@ -83,7 +83,7 @@ where
 /// per-proof entropy can be folded in without touching the originating
 /// `RingVerifier`. The transcript's initial state is not load-bearing; any
 /// valid `T` works (e.g. the prelude of any ring verifier being batched).
-pub struct MultiRingBatchVerifier<E: Pairing, T>
+pub struct BatchVerifier<E: Pairing, T>
 where
     T: PlonkTranscript<E::ScalarField, KZG<E>>,
 {
@@ -91,7 +91,7 @@ where
     transcript: T,
 }
 
-impl<E: Pairing, T> MultiRingBatchVerifier<E, T>
+impl<E: Pairing, T> BatchVerifier<E, T>
 where
     T: PlonkTranscript<E::ScalarField, KZG<E>>,
 {

--- a/w3f-ring-proof/src/multi_ring_batch_verifier.rs
+++ b/w3f-ring-proof/src/multi_ring_batch_verifier.rs
@@ -26,12 +26,10 @@ where
     entropy: [u8; 32],
 }
 
-/// Accumulating batch verifier for ring proofs across multiple rings.
+/// Accumulating batch verifier for ring proofs across one or more rings.
 ///
-/// Unlike `KzgBatchVerifier` which is tied to a single ring, this verifier
-/// accumulates proofs from different rings (keysets) into a single batched
-/// pairing check. All rings must share the same KZG SRS and the same
-/// transcript type `T`.
+/// Accumulates proofs from one or more rings (keysets) into a single batched
+/// pairing check. All rings must share the same KZG SRS.
 ///
 /// Holds its own transcript instance, cloned on each `push_prepared` so the
 /// per-proof entropy can be folded in without touching the originating

--- a/w3f-ring-proof/src/multi_ring_batch_verifier.rs
+++ b/w3f-ring-proof/src/multi_ring_batch_verifier.rs
@@ -15,7 +15,7 @@ use crate::ring_verifier::RingVerifier;
 use crate::RingProof;
 
 /// A ring proof preprocessed for multi-ring batch verification.
-pub struct PreparedMultiRingItem<E, J>
+pub struct BatchItem<E, J>
 where
     E: Pairing,
     J: TECurveConfig<BaseField = E::ScalarField>,
@@ -24,6 +24,54 @@ where
     proof: RingProof<E::ScalarField, KZG<E>>,
     challenges: Challenges<E::ScalarField>,
     entropy: [u8; 32],
+}
+
+impl<E, J> BatchItem<E, J>
+where
+    E: Pairing,
+    J: TECurveConfig<BaseField = E::ScalarField>,
+{
+    /// Prepares a ring proof for batch verification without accumulating it.
+    ///
+    /// The returned item is independent of both any accumulator state and
+    /// the originating `RingVerifier`, so multiple proofs (even from
+    /// different rings) can be prepared in parallel.
+    pub fn new<T>(
+        verifier: &RingVerifier<E::ScalarField, KZG<E>, J, T>,
+        proof: RingProof<E::ScalarField, KZG<E>>,
+        result: Affine<J>,
+    ) -> Self
+    where
+        T: PlonkTranscript<E::ScalarField, KZG<E>>,
+    {
+        let (challenges, mut rng) = verifier.plonk_verifier.restore_challenges(
+            &result,
+            &proof,
+            PiopVerifier::<E::ScalarField, <KZG<E> as PCS<_>>::C, Affine<J>>::N_COLUMNS + 1,
+            PiopVerifier::<E::ScalarField, <KZG<E> as PCS<_>>::C, Affine<J>>::N_CONSTRAINTS,
+        );
+        let seed = verifier.piop_params.seed;
+        let seed_plus_result = (seed + result).into_affine();
+        let domain_at_zeta = verifier.piop_params.domain.evaluate(challenges.zeta);
+        let piop = PiopVerifier::<_, _, Affine<J>>::init(
+            domain_at_zeta,
+            verifier.fixed_columns_committed.clone(),
+            proof.column_commitments.clone(),
+            proof.columns_at_zeta.clone(),
+            (seed.x, seed.y),
+            (seed_plus_result.x, seed_plus_result.y),
+        );
+
+        let mut entropy = [0_u8; 32];
+        rng.fill_bytes(&mut entropy);
+
+        Self {
+            piop,
+            proof,
+            challenges,
+            entropy,
+        }
+    }
 }
 
 /// Accumulating batch verifier for ring proofs across one or more rings.
@@ -55,54 +103,8 @@ where
         }
     }
 
-    /// Prepares a ring proof for batch verification without accumulating it.
-    ///
-    /// The returned item is independent of both the accumulator state and
-    /// the originating `RingVerifier`, so multiple proofs (even from
-    /// different rings) can be prepared in parallel.
-    pub fn prepare<J>(
-        verifier: &RingVerifier<E::ScalarField, KZG<E>, J, T>,
-        proof: RingProof<E::ScalarField, KZG<E>>,
-        result: Affine<J>,
-    ) -> PreparedMultiRingItem<E, J>
-    where
-        J: TECurveConfig<BaseField = E::ScalarField>,
-    {
-        let (challenges, mut rng) = verifier.plonk_verifier.restore_challenges(
-            &result,
-            &proof,
-            PiopVerifier::<E::ScalarField, <KZG<E> as PCS<_>>::C, Affine<J>>::N_COLUMNS + 1,
-            PiopVerifier::<E::ScalarField, <KZG<E> as PCS<_>>::C, Affine<J>>::N_CONSTRAINTS,
-        );
-        let seed = verifier.piop_params.seed;
-        let seed_plus_result = (seed + result).into_affine();
-        let domain_at_zeta = verifier.piop_params.domain.evaluate(challenges.zeta);
-        let piop = PiopVerifier::<_, _, Affine<J>>::init(
-            domain_at_zeta,
-            verifier.fixed_columns_committed.clone(),
-            proof.column_commitments.clone(),
-            proof.columns_at_zeta.clone(),
-            (seed.x, seed.y),
-            (seed_plus_result.x, seed_plus_result.y),
-        );
-
-        let mut entropy = [0_u8; 32];
-        rng.fill_bytes(&mut entropy);
-
-        PreparedMultiRingItem {
-            piop,
-            proof,
-            challenges,
-            entropy,
-        }
-    }
-
-    /// Accumulates a previously prepared proof into the batch.
-    ///
-    /// This is the second step of the two-phase batch verification workflow:
-    /// 1. `prepare` - can be parallelized across multiple proofs
-    /// 2. `push_prepared` - must be called sequentially (mutates the accumulator)
-    pub fn push_prepared<J>(&mut self, item: PreparedMultiRingItem<E, J>)
+    /// Accumulates a prepared `BatchItem` into the batch.
+    pub fn push<J>(&mut self, item: BatchItem<E, J>)
     where
         J: TECurveConfig<BaseField = E::ScalarField>,
     {
@@ -112,8 +114,15 @@ where
             .accumulate(item.piop, item.proof, item.challenges, &mut ts.to_rng());
     }
 
-    /// Adds a ring proof to the batch, preparing and accumulating it immediately.
-    pub fn push<J>(
+    /// Adds a raw ring proof to the batch.
+    ///
+    /// Equivalent to `self.push(BatchItem::new(verifier, proof, result))`:
+    /// preparation (transcript replay, challenge derivation, PIOP setup) and
+    /// accumulation happen internally. Use the two-step form directly when
+    /// preparation should be parallelized — `BatchItem::new` is independent
+    /// of the accumulator state, so multiple items can be built in parallel
+    /// and then pushed sequentially via [`push`](Self::push).
+    pub fn push_raw<J>(
         &mut self,
         verifier: &RingVerifier<E::ScalarField, KZG<E>, J, T>,
         proof: RingProof<E::ScalarField, KZG<E>>,
@@ -121,8 +130,7 @@ where
     ) where
         J: TECurveConfig<BaseField = E::ScalarField>,
     {
-        let item = Self::prepare(verifier, proof, result);
-        self.push_prepared(item);
+        self.push(BatchItem::new(verifier, proof, result));
     }
 
     /// Verifies all accumulated proofs in a single batched pairing check.

--- a/w3f-ring-proof/src/multi_ring_batch_verifier.rs
+++ b/w3f-ring-proof/src/multi_ring_batch_verifier.rs
@@ -15,16 +15,11 @@ use crate::ring_verifier::RingVerifier;
 use crate::RingProof;
 
 /// A ring proof preprocessed for multi-ring batch verification.
-///
-/// Holds a reference to the `RingVerifier` that was used during preparation,
-/// so that `push_prepared` can access the correct ring's transcript prelude.
-pub struct PreparedMultiRingItem<'a, E, J, T>
+pub struct PreparedMultiRingItem<E, J>
 where
     E: Pairing,
     J: TECurveConfig<BaseField = E::ScalarField>,
-    T: PlonkTranscript<E::ScalarField, KZG<E>>,
 {
-    verifier: &'a RingVerifier<E::ScalarField, KZG<E>, J, T>,
     piop: PiopVerifier<E::ScalarField, <KZG<E> as PCS<E::ScalarField>>::C, Affine<J>>,
     proof: RingProof<E::ScalarField, KZG<E>>,
     challenges: Challenges<E::ScalarField>,
@@ -33,36 +28,47 @@ where
 
 /// Accumulating batch verifier for ring proofs across multiple rings.
 ///
-/// Unlike `KzgBatchVerifier` which is tied to a single ring,
-/// this verifier can accumulate proofs from different rings (keysets)
-/// into a single batched pairing check.
+/// Unlike `KzgBatchVerifier` which is tied to a single ring, this verifier
+/// accumulates proofs from different rings (keysets) into a single batched
+/// pairing check. All rings must share the same KZG SRS and the same
+/// transcript type `T`.
 ///
-/// All rings must share the same KZG SRS (same `KzgVerifierKey`).
-pub struct MultiRingBatchVerifier<E: Pairing> {
+/// Holds its own transcript instance, cloned on each `push_prepared` so the
+/// per-proof entropy can be folded in without touching the originating
+/// `RingVerifier`. The transcript's initial state is not load-bearing; any
+/// valid `T` works (e.g. the prelude of any ring verifier being batched).
+pub struct MultiRingBatchVerifier<E: Pairing, T>
+where
+    T: PlonkTranscript<E::ScalarField, KZG<E>>,
+{
     acc: KzgAccumulator<E>,
+    transcript: T,
 }
 
-impl<E: Pairing> MultiRingBatchVerifier<E> {
+impl<E: Pairing, T> MultiRingBatchVerifier<E, T>
+where
+    T: PlonkTranscript<E::ScalarField, KZG<E>>,
+{
     /// Creates a new multi-ring batch verifier.
-    pub fn new(kzg_vk: KzgVerifierKey<E>) -> Self {
+    pub fn new(kzg_vk: KzgVerifierKey<E>, transcript: T) -> Self {
         Self {
             acc: KzgAccumulator::<E>::new(kzg_vk),
+            transcript,
         }
     }
 
     /// Prepares a ring proof for batch verification without accumulating it.
     ///
-    /// The returned item holds a reference to the `verifier` and is independent
-    /// of the accumulator state, so multiple proofs (even from different rings)
-    /// can be prepared in parallel.
-    pub fn prepare<'a, J, T>(
-        verifier: &'a RingVerifier<E::ScalarField, KZG<E>, J, T>,
+    /// The returned item is independent of both the accumulator state and
+    /// the originating `RingVerifier`, so multiple proofs (even from
+    /// different rings) can be prepared in parallel.
+    pub fn prepare<J>(
+        verifier: &RingVerifier<E::ScalarField, KZG<E>, J, T>,
         proof: RingProof<E::ScalarField, KZG<E>>,
         result: Affine<J>,
-    ) -> PreparedMultiRingItem<'a, E, J, T>
+    ) -> PreparedMultiRingItem<E, J>
     where
         J: TECurveConfig<BaseField = E::ScalarField>,
-        T: PlonkTranscript<E::ScalarField, KZG<E>>,
     {
         let (challenges, mut rng) = verifier.plonk_verifier.restore_challenges(
             &result,
@@ -86,7 +92,6 @@ impl<E: Pairing> MultiRingBatchVerifier<E> {
         rng.fill_bytes(&mut entropy);
 
         PreparedMultiRingItem {
-            verifier,
             piop,
             proof,
             challenges,
@@ -99,26 +104,24 @@ impl<E: Pairing> MultiRingBatchVerifier<E> {
     /// This is the second step of the two-phase batch verification workflow:
     /// 1. `prepare` - can be parallelized across multiple proofs
     /// 2. `push_prepared` - must be called sequentially (mutates the accumulator)
-    pub fn push_prepared<J, T>(&mut self, item: PreparedMultiRingItem<'_, E, J, T>)
+    pub fn push_prepared<J>(&mut self, item: PreparedMultiRingItem<E, J>)
     where
         J: TECurveConfig<BaseField = E::ScalarField>,
-        T: PlonkTranscript<E::ScalarField, KZG<E>>,
     {
-        let mut ts = item.verifier.plonk_verifier.transcript_prelude.clone();
+        let mut ts = self.transcript.clone();
         ts._add_serializable(b"batch-entropy", &item.entropy);
         self.acc
             .accumulate(item.piop, item.proof, item.challenges, &mut ts.to_rng());
     }
 
     /// Adds a ring proof to the batch, preparing and accumulating it immediately.
-    pub fn push<J, T>(
+    pub fn push<J>(
         &mut self,
         verifier: &RingVerifier<E::ScalarField, KZG<E>, J, T>,
         proof: RingProof<E::ScalarField, KZG<E>>,
         result: Affine<J>,
     ) where
         J: TECurveConfig<BaseField = E::ScalarField>,
-        T: PlonkTranscript<E::ScalarField, KZG<E>>,
     {
         let item = Self::prepare(verifier, proof, result);
         self.push_prepared(item);

--- a/w3f-ring-proof/src/multi_ring_batch_verifier.rs
+++ b/w3f-ring-proof/src/multi_ring_batch_verifier.rs
@@ -79,8 +79,8 @@ where
 /// Accumulates proofs from one or more rings (keysets) into a single batched
 /// pairing check. All rings must share the same KZG SRS.
 ///
-/// Holds its own transcript instance, cloned on each `push_prepared` so the
-/// per-proof entropy can be folded in without touching the originating
+/// Holds its own transcript instance, cloned on each `push_prepared` call so
+/// the per-proof entropy can be folded in without touching the originating
 /// `RingVerifier`. The transcript's initial state is not load-bearing; any
 /// valid `T` works (e.g. the prelude of any ring verifier being batched).
 pub struct BatchVerifier<E: Pairing, T>
@@ -103,26 +103,8 @@ where
         }
     }
 
-    /// Accumulates a prepared `BatchItem` into the batch.
-    pub fn push<J>(&mut self, item: BatchItem<E, J>)
-    where
-        J: TECurveConfig<BaseField = E::ScalarField>,
-    {
-        let mut ts = self.transcript.clone();
-        ts._add_serializable(b"batch-entropy", &item.entropy);
-        self.acc
-            .accumulate(item.piop, item.proof, item.challenges, &mut ts.to_rng());
-    }
-
-    /// Adds a raw ring proof to the batch.
-    ///
-    /// Equivalent to `self.push(BatchItem::new(verifier, proof, result))`:
-    /// preparation (transcript replay, challenge derivation, PIOP setup) and
-    /// accumulation happen internally. Use the two-step form directly when
-    /// preparation should be parallelized — `BatchItem::new` is independent
-    /// of the accumulator state, so multiple items can be built in parallel
-    /// and then pushed sequentially via [`push`](Self::push).
-    pub fn push_raw<J>(
+    /// Adds a ring proof to the batch.
+    pub fn push<J>(
         &mut self,
         verifier: &RingVerifier<E::ScalarField, KZG<E>, J, T>,
         proof: RingProof<E::ScalarField, KZG<E>>,
@@ -130,7 +112,25 @@ where
     ) where
         J: TECurveConfig<BaseField = E::ScalarField>,
     {
-        self.push(BatchItem::new(verifier, proof, result));
+        self.push_prepared(BatchItem::new(verifier, proof, result));
+    }
+
+    /// Accumulates a prepared [`BatchItem`] into the batch.
+    ///
+    /// Equivalent to [`push`](Self::push), but splits the work: the caller
+    /// builds the [`BatchItem`] (transcript replay, challenge derivation,
+    /// PIOP setup) separately from accumulation. Useful when preparation
+    /// should be parallelized. `BatchItem::new` is independent of the
+    /// accumulator state, so multiple items can be built in parallel and
+    /// then pushed sequentially here.
+    pub fn push_prepared<J>(&mut self, item: BatchItem<E, J>)
+    where
+        J: TECurveConfig<BaseField = E::ScalarField>,
+    {
+        let mut ts = self.transcript.clone();
+        ts._add_serializable(b"batch-entropy", &item.entropy);
+        self.acc
+            .accumulate(item.piop, item.proof, item.challenges, &mut ts.to_rng());
     }
 
     /// Verifies all accumulated proofs in a single batched pairing check.

--- a/w3f-ring-proof/src/ring_verifier.rs
+++ b/w3f-ring-proof/src/ring_verifier.rs
@@ -112,7 +112,7 @@ where
             self.plonk_verifier.transcript_prelude.clone(),
         );
         for (proof, result) in proofs.into_iter().zip(results) {
-            batch.push_raw(self, proof, result);
+            batch.push(self, proof, result);
         }
         batch.verify()
     }

--- a/w3f-ring-proof/src/ring_verifier.rs
+++ b/w3f-ring-proof/src/ring_verifier.rs
@@ -2,14 +2,13 @@ use ark_ec::pairing::Pairing;
 use ark_ec::twisted_edwards::{Affine, TECurveConfig};
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
-use ark_std::rand::RngCore;
 use w3f_pcs::pcs::kzg::KZG;
 use w3f_pcs::pcs::{RawVerifierKey, PCS};
-use w3f_plonk_common::kzg_acc::KzgAccumulator;
 use w3f_plonk_common::piop::VerifierPiop;
 use w3f_plonk_common::transcript::PlonkTranscript;
-use w3f_plonk_common::verifier::{Challenges, PlonkVerifier};
+use w3f_plonk_common::verifier::PlonkVerifier;
 
+use crate::multi_ring_batch_verifier::MultiRingBatchVerifier;
 use crate::piop::params::PiopParams;
 use crate::piop::{FixedColumnsCommitted, PiopVerifier, VerifierKey};
 use crate::{ArkTranscript, RingProof};
@@ -95,131 +94,25 @@ where
     }
 }
 
-/// Accumulating batch verifier for ring proofs using KZG polynomial commitment scheme.
-pub struct KzgBatchVerifier<E, J, T = ArkTranscript>
-where
-    E: Pairing,
-    J: TECurveConfig<BaseField = E::ScalarField>,
-    T: PlonkTranscript<E::ScalarField, KZG<E>>,
-{
-    pub acc: KzgAccumulator<E>,
-    pub verifier: RingVerifier<E::ScalarField, KZG<E>, J, T>,
-}
-
-/// A ring proof that has been preprocessed for batch verification.
-pub struct PreparedBatchItem<E, J>
-where
-    E: Pairing,
-    J: TECurveConfig<BaseField = E::ScalarField>,
-{
-    piop: PiopVerifier<E::ScalarField, <KZG<E> as PCS<E::ScalarField>>::C, Affine<J>>,
-    proof: RingProof<E::ScalarField, KZG<E>>,
-    challenges: Challenges<E::ScalarField>,
-    entropy: [u8; 32],
-}
-
-impl<E, J, T> KzgBatchVerifier<E, J, T>
-where
-    E: Pairing,
-    J: TECurveConfig<BaseField = E::ScalarField>,
-    T: PlonkTranscript<E::ScalarField, KZG<E>>,
-{
-    /// Prepares a ring proof for batch verification without accumulating it.
-    ///
-    /// Returns a `PreparedBatchItem` that can later be passed to `push_prepared`.
-    ///
-    /// This method is independent of the accumulator state, so multiple proofs can be
-    /// prepared in parallel (e.g., using `rayon`). Each prepared item is in the order
-    /// of a few KB, so for large batches you may want to prepare and push incrementally
-    /// rather than holding all prepared items in memory at once.
-    pub fn prepare(
-        &self,
-        proof: RingProof<E::ScalarField, KZG<E>>,
-        result: Affine<J>,
-    ) -> PreparedBatchItem<E, J> {
-        let (challenges, mut rng) = self.verifier.plonk_verifier.restore_challenges(
-            &result,
-            &proof,
-            // '1' accounts for the quotient polynomial that is aggregated together with the columns
-            PiopVerifier::<E::ScalarField, <KZG<E> as PCS<_>>::C, Affine<J>>::N_COLUMNS + 1,
-            PiopVerifier::<E::ScalarField, <KZG<E> as PCS<_>>::C, Affine<J>>::N_CONSTRAINTS,
-        );
-        let seed = self.verifier.piop_params.seed;
-        let seed_plus_result = (seed + result).into_affine();
-        let domain_at_zeta = self.verifier.piop_params.domain.evaluate(challenges.zeta);
-        let piop = PiopVerifier::<_, _, Affine<J>>::init(
-            domain_at_zeta,
-            self.verifier.fixed_columns_committed.clone(),
-            proof.column_commitments.clone(),
-            proof.columns_at_zeta.clone(),
-            (seed.x, seed.y),
-            (seed_plus_result.x, seed_plus_result.y),
-        );
-
-        // Pick some entropy from plonk verifier for later usage
-        let mut entropy = [0_u8; 32];
-        rng.fill_bytes(&mut entropy);
-
-        PreparedBatchItem {
-            piop,
-            proof,
-            challenges,
-            entropy,
-        }
-    }
-
-    /// Accumulates a previously prepared proof into the batch.
-    ///
-    /// This is the second step of the two-phase batch verification workflow:
-    /// 1. `prepare` - can be parallelized across multiple proofs
-    /// 2. `push_prepared` - must be called sequentially (mutates the accumulator)
-    ///
-    /// For simpler usage where parallelism isn't needed, use `push` instead.
-    pub fn push_prepared(&mut self, item: PreparedBatchItem<E, J>) {
-        let mut ts = self.verifier.plonk_verifier.transcript_prelude.clone();
-        ts._add_serializable(b"batch-entropy", &item.entropy);
-        self.acc
-            .accumulate(item.piop, item.proof, item.challenges, &mut ts.to_rng());
-    }
-
-    /// Adds a ring proof to the batch, preparing and accumulating it immediately.
-    ///
-    /// The proof's pairing equation is aggregated into the internal accumulator.
-    /// Call `verify` after pushing all proofs to perform the batched verification.
-    pub fn push(&mut self, proof: RingProof<E::ScalarField, KZG<E>>, result: Affine<J>) {
-        let item = self.prepare(proof, result);
-        self.push_prepared(item);
-    }
-
-    /// Verifies all accumulated proofs in a single batched pairing check.
-    pub fn verify(&self) -> bool {
-        self.acc.verify()
-    }
-}
-
 impl<E, J, T> RingVerifier<E::ScalarField, KZG<E>, J, T>
 where
     E: Pairing,
     J: TECurveConfig<BaseField = E::ScalarField>,
     T: PlonkTranscript<E::ScalarField, KZG<E>>,
 {
-    /// Build a new batch verifier.
-    pub fn kzg_batch_verifier(self) -> KzgBatchVerifier<E, J, T> {
-        KzgBatchVerifier {
-            acc: KzgAccumulator::<E>::new(self.plonk_verifier.pcs_vk.clone()),
-            verifier: self,
-        }
-    }
-
-    /// Verifies a batch of proofs against the same ring.
+    /// Verifies a batch of proofs against this ring in a single batched
+    /// pairing check, using a `MultiRingBatchVerifier` under the hood.
     pub fn verify_batch_kzg(
-        self,
+        &self,
         proofs: Vec<RingProof<E::ScalarField, KZG<E>>>,
         results: Vec<Affine<J>>,
     ) -> bool {
-        let mut batch = self.kzg_batch_verifier();
+        let mut batch = MultiRingBatchVerifier::new(
+            self.plonk_verifier.pcs_vk.clone(),
+            self.plonk_verifier.transcript_prelude.clone(),
+        );
         for (proof, result) in proofs.into_iter().zip(results) {
-            batch.push(proof, result);
+            batch.push(self, proof, result);
         }
         batch.verify()
     }

--- a/w3f-ring-proof/src/ring_verifier.rs
+++ b/w3f-ring-proof/src/ring_verifier.rs
@@ -112,7 +112,7 @@ where
             self.plonk_verifier.transcript_prelude.clone(),
         );
         for (proof, result) in proofs.into_iter().zip(results) {
-            batch.push(self, proof, result);
+            batch.push_raw(self, proof, result);
         }
         batch.verify()
     }

--- a/w3f-ring-proof/src/ring_verifier.rs
+++ b/w3f-ring-proof/src/ring_verifier.rs
@@ -8,7 +8,7 @@ use w3f_plonk_common::piop::VerifierPiop;
 use w3f_plonk_common::transcript::PlonkTranscript;
 use w3f_plonk_common::verifier::PlonkVerifier;
 
-use crate::multi_ring_batch_verifier::MultiRingBatchVerifier;
+use crate::multi_ring_batch_verifier::BatchVerifier;
 use crate::piop::params::PiopParams;
 use crate::piop::{FixedColumnsCommitted, PiopVerifier, VerifierKey};
 use crate::{ArkTranscript, RingProof};
@@ -107,7 +107,7 @@ where
         proofs: Vec<RingProof<E::ScalarField, KZG<E>>>,
         results: Vec<Affine<J>>,
     ) -> bool {
-        let mut batch = MultiRingBatchVerifier::new(
+        let mut batch = BatchVerifier::new(
             self.plonk_verifier.pcs_vk.clone(),
             self.plonk_verifier.transcript_prelude.clone(),
         );


### PR DESCRIPTION
Closes https://github.com/paritytech/ring-proof/issues/73

Replace `KzgBatchVerifier` with a thin wrapper around `MultiRingBatchVerifier` (now just `BatchVerifier`)

---

Bonus: simplify `BatchItem`:

`BatchItem` (then named `PreparedMultiRingItem`) used to borrow `RingVerifier` solely so the batch verifier could clone the verifier's transcript when folding in per-item entropy. That borrow leaked a lifetime and a transcript type parameter into the item and every method touching it.

An overarching transcript is now owned by `BatchVerifier`, passed once at construction (`BatchVerifier::new(kzg_vk, transcript)`), and cloned on each push to fold entropy. As a result `BatchItem` is now a plain owned struct and self-contained so they can be stored/sent, decoupled from the originating verifier.





