### PR TITLE
pcs opening split out of the plonk prover

### DIFF
--- a/w3f-plonk-common/src/lib.rs
+++ b/w3f-plonk-common/src/lib.rs
@@ -88,6 +88,9 @@ fn is_in_correct_subgroup_assuming_on_curve<E: Pairing>(p: &E::G1Affine) -> bool
     p.mul_bigint(r).is_zero()
 }
 
+/// Vanilla plonk proof:
+/// - column and quotient polynomials are opened in a single point `zeta`
+/// - the linearization polynomial is opened in another (shifted) point `zeta * omega`
 #[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<F, CS, Commitments, Evaluations>
 where
@@ -102,4 +105,19 @@ where
     pub lin_at_zeta_omega: F,
     pub agg_at_zeta_proof: CS::Proof,
     pub lin_at_zeta_omega_proof: CS::Proof,
+}
+
+/// Same as `Proof` but excluding the PCS opening.
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct PlonkProof<F, C, Commitments, Evaluations>
+where
+    F: PrimeField,
+    C: Commitment<F>,
+    Commitments: ColumnsCommited<F, C>,
+    Evaluations: ColumnsEvaluated<F>,
+{
+    pub column_commitments: Commitments,
+    pub columns_at_zeta: Evaluations,
+    pub quotient_commitment: C,
+    pub lin_at_zeta_omega: F,
 }

--- a/w3f-plonk-common/src/prover.rs
+++ b/w3f-plonk-common/src/prover.rs
@@ -1,13 +1,17 @@
 use ark_ff::PrimeField;
+use ark_poly::univariate::DensePolynomial;
 use ark_poly::{Evaluations, Polynomial};
 use ark_serialize::CanonicalSerialize;
-use ark_std::vec;
+use ark_std::format;
+use ark_std::vec::Vec;
+use ark_std::{end_timer, start_timer, vec};
+
 use w3f_pcs::aggregation::single::aggregate_polys;
 use w3f_pcs::pcs::PCS;
 
 use crate::piop::ProverPiop;
 use crate::transcript::PlonkTranscript;
-use crate::Proof;
+use crate::{PlonkProof, Proof};
 
 pub struct PlonkProver<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> {
     // Polynomial commitment scheme committer's key.
@@ -15,6 +19,13 @@ pub struct PlonkProver<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> {
     // Transcript,
     // initialized with the public parameters and the commitments to the precommitted columns.
     transcript_prelude: T,
+}
+
+pub struct PcsOpeningAt2Points<F: PrimeField> {
+    pub polys_at_zeta: Vec<DensePolynomial<F>>,
+    pub polys_at_zeta_omega: Vec<DensePolynomial<F>>,
+    pub zeta: F,
+    pub zeta_omega: F,
 }
 
 impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T> {
@@ -32,7 +43,14 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
         }
     }
 
-    pub fn prove<P>(&self, piop: P) -> Proof<F, CS, P::Commitments, P::Evaluations>
+    pub fn reduce_to_pcs_opening<P>(
+        &self,
+        piop: P,
+    ) -> (
+        PcsOpeningAt2Points<F>,
+        PlonkProof<F, CS::C, P::Commitments, P::Evaluations>,
+        T,
+    )
     where
         P: ProverPiop<F, CS::C>,
     {
@@ -67,12 +85,49 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
         let zeta_omega = zeta * omega;
         let lin_at_zeta_omega = lin.evaluate(&zeta_omega);
         transcript.add_evaluations(&columns_at_zeta, &lin_at_zeta_omega);
-
+        let plonk_proof = PlonkProof {
+            column_commitments,
+            quotient_commitment,
+            columns_at_zeta,
+            lin_at_zeta_omega,
+        };
         let polys_at_zeta = [columns_to_open, vec![quotient_poly]].concat();
+        let pcs_openings = PcsOpeningAt2Points {
+            polys_at_zeta,
+            polys_at_zeta_omega: vec![lin],
+            zeta,
+            zeta_omega,
+        };
+        (pcs_openings, plonk_proof, transcript)
+    }
+
+    pub fn prove<P>(&self, piop: P) -> Proof<F, CS, P::Commitments, P::Evaluations>
+    where
+        P: ProverPiop<F, CS::C>,
+    {
+        let (pcs_openings, plonk_proof, mut transcript) = self.reduce_to_pcs_opening(piop);
+        let PcsOpeningAt2Points {
+            polys_at_zeta,
+            polys_at_zeta_omega,
+            zeta,
+            zeta_omega,
+        } = pcs_openings;
+        let lin = &polys_at_zeta_omega[0];
+        let PlonkProof {
+            column_commitments,
+            quotient_commitment,
+            columns_at_zeta,
+            lin_at_zeta_omega,
+        } = plonk_proof;
+
         let nus = transcript.get_kzg_aggregation_challenges(polys_at_zeta.len());
         let agg_at_zeta = aggregate_polys(&polys_at_zeta, &nus);
+        let _t_open_zeta = start_timer!(|| format!("Opening deg(f)={}", agg_at_zeta.degree()));
         let agg_at_zeta_proof = CS::open(&self.pcs_ck, &agg_at_zeta, zeta).unwrap();
-        let lin_at_zeta_omega_proof = CS::open(&self.pcs_ck, &lin, zeta_omega).unwrap();
+        end_timer!(_t_open_zeta);
+        let _t_open_zeta_omega = start_timer!(|| format!("Opening deg(f)={}", lin.degree()));
+        let lin_at_zeta_omega_proof = CS::open(&self.pcs_ck, lin, zeta_omega).unwrap();
+        end_timer!(_t_open_zeta_omega);
         Proof {
             column_commitments,
             quotient_commitment,


### PR DESCRIPTION
Non-breaking change. In IPA PCS opening is more consuming than in KZG, so should be batched differently.