### PR TITLE
Chunking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ ark-ec = { version = "0.6", default-features = false }
 ark-poly = { version = "0.6", default-features = false }
 ark-serialize = { version = "0.6", default-features = false, features = ["derive"] }
 #w3f-pcs = { version = "0.0.6", default-features = false }
-w3f-pcs = { path = "../fflonk", default-features = false }
-#w3f-pcs = { version = "0.0.6", git = "https://github.com/paritytech/fflonk/", branch = "ipa-pcs", default-features = false }
+#w3f-pcs = { path = "../fflonk", default-features = false }
+w3f-pcs = { version = "0.0.6", git = "https://github.com/paritytech/fflonk/", branch = "ipa-pcs", default-features = false }
 #w3f-plonk-common = { version = "0.0.7", default-features = false }
 w3f-plonk-common = { path = "w3f-plonk-common", default-features = false }
 rayon = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ ark-ec = { version = "0.6", default-features = false }
 ark-poly = { version = "0.6", default-features = false }
 ark-serialize = { version = "0.6", default-features = false, features = ["derive"] }
 #w3f-pcs = { version = "0.0.6", default-features = false }
-#w3f-pcs = { path = "../fflonk", default-features = false }
-w3f-pcs = { version = "0.0.6", git = "https://github.com/paritytech/fflonk/", branch = "ipa-pcs", default-features = false }
+w3f-pcs = { path = "../fflonk", default-features = false }
+#w3f-pcs = { version = "0.0.6", git = "https://github.com/paritytech/fflonk/", branch = "ipa-pcs", default-features = false }
 #w3f-plonk-common = { version = "0.0.7", default-features = false }
 w3f-plonk-common = { path = "w3f-plonk-common", default-features = false }
 rayon = { version = "1", default-features = false }

--- a/pasta-tree/src/circuit_fat/params.rs
+++ b/pasta-tree/src/circuit_fat/params.rs
@@ -13,6 +13,9 @@ use w3f_plonk_common::domain::Domain;
 use w3f_plonk_common::gadgets::booleanity::BitColumn;
 use w3f_plonk_common::gadgets::ec::AffineColumn;
 
+// Hiding Pedersen commitment opened in `2` points.
+pub const ZK_ROWS: usize = 3;
+
 /// Plonk Interactive Oracle Proofs (PIOP) parameters.
 #[derive(Clone)]
 pub struct PiopParams<G: AffineRepr<BaseField: PrimeField>> {
@@ -74,7 +77,8 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>> CircuitParams<C, 
     }
 
     #[cfg(test)]
-    fn setup(domain: Domain<G::BaseField>, h: G, _seed: G) -> Self {
+    fn setup(domain_size: usize, h: G, _seed: G) -> Self {
+        let domain = Domain::<G::BaseField>::with_zk_rows(domain_size, ZK_ROWS);
         Self::setup(domain, h)
     }
 }

--- a/pasta-tree/src/circuit_fat/params.rs
+++ b/pasta-tree/src/circuit_fat/params.rs
@@ -14,7 +14,7 @@ use w3f_plonk_common::gadgets::booleanity::BitColumn;
 use w3f_plonk_common::gadgets::ec::AffineColumn;
 
 // Hiding Pedersen commitment opened in `2` points.
-pub const ZK_ROWS: usize = 3;
+pub const ZK_ROWS: usize = 2;
 
 /// Plonk Interactive Oracle Proofs (PIOP) parameters.
 #[derive(Clone)]

--- a/pasta-tree/src/circuit_fat/prover.rs
+++ b/pasta-tree/src/circuit_fat/prover.rs
@@ -6,11 +6,13 @@ use ark_ec::AffineRepr;
 use ark_ec::CurveGroup;
 use ark_ff::One;
 use ark_ff::{FftField, PrimeField, Zero};
-use ark_poly::univariate::DensePolynomial;
 use ark_poly::Evaluations;
+use ark_poly::univariate::DensePolynomial;
 use ark_std::{vec, vec::Vec};
 use w3f_pcs::pcs::commitment::WrappedAffine;
+use w3f_plonk_common::FieldColumn;
 use w3f_plonk_common::domain::Domain;
+use w3f_plonk_common::gadgets::ProverGadget;
 use w3f_plonk_common::gadgets::booleanity::{BitColumn, Booleanity};
 use w3f_plonk_common::gadgets::column_sum::ColumnSumPolys;
 use w3f_plonk_common::gadgets::ec::AffineColumn;
@@ -18,9 +20,7 @@ use w3f_plonk_common::gadgets::ec::CondAdd;
 use w3f_plonk_common::gadgets::equal_cells::CellsEqPolys;
 use w3f_plonk_common::gadgets::fixed_cells::FixedCells;
 use w3f_plonk_common::gadgets::inner_prod_inv::InnerProdInv;
-use w3f_plonk_common::gadgets::ProverGadget;
 use w3f_plonk_common::piop::ProverPiop;
-use w3f_plonk_common::FieldColumn;
 
 pub struct PiopProver<G: AffineRepr<BaseField: FftField>> {
     domain: Domain<G::BaseField>,
@@ -160,8 +160,8 @@ impl<G: CurveModel<BaseField: PrimeField>> PiopProver<AffinePoint<G>> {
     }
 }
 
-impl<C: CurveGroup, G: CurveModel<BaseField=C::ScalarField>>
-ProverPiop<C::ScalarField, WrappedAffine<C>> for PiopProver<AffinePoint<G>>
+impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
+    ProverPiop<C::ScalarField, WrappedAffine<C>> for PiopProver<AffinePoint<G>>
 {
     const N_COLUMNS: usize = 9;
     const N_CONSTRAINTS: usize = 12;
@@ -227,7 +227,7 @@ ProverPiop<C::ScalarField, WrappedAffine<C>> for PiopProver<AffinePoint<G>>
                 C::ScalarField::one(),
             )],
         ]
-            .concat()
+        .concat()
     }
 
     fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
@@ -249,7 +249,7 @@ ProverPiop<C::ScalarField, WrappedAffine<C>> for PiopProver<AffinePoint<G>>
             // vec![DensePolynomial::zero()],
             vec![DensePolynomial::zero()],
         ]
-            .concat()
+        .concat()
     }
 
     fn domain(&self) -> &Domain<C::ScalarField> {
@@ -267,7 +267,7 @@ mod tests {
     use crate::tests::random_witness;
     use ark_bls12_381::G1Projective;
     use ark_ed_on_bls12_381_bandersnatch::{Fq, Fr, SWAffine};
-    use ark_std::{test_rng, UniformRand};
+    use ark_std::{UniformRand, test_rng};
     use w3f_pcs::pcs::commitment::WrappedAffine;
 
     #[test]

--- a/pasta-tree/src/circuit_fat/prover.rs
+++ b/pasta-tree/src/circuit_fat/prover.rs
@@ -171,14 +171,6 @@ impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
     type Evaluations = ProofEvals<C::ScalarField>;
     type Instance = AffinePoint<G>;
 
-    fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
-        let chunks =
-            <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas);
-        debug_assert_eq!(chunks.as_ref().unwrap().len(), 4);
-        debug_assert_eq!(chunks.as_ref().unwrap()[3].degree(), 0);
-        chunks
-    }
-
     fn committed_columns<Fun: Fn(&DensePolynomial<C::ScalarField>) -> WrappedAffine<C>>(
         &self,
         commit: Fun,
@@ -236,6 +228,14 @@ impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
             )],
         ]
         .concat()
+    }
+
+    fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
+        let chunks =
+            <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas);
+        debug_assert_eq!(chunks.as_ref().unwrap().len(), 4);
+        debug_assert_eq!(chunks.as_ref().unwrap()[3].degree(), 0);
+        chunks
     }
 
     fn constraints_lin(&self, zeta: &C::ScalarField) -> Vec<DensePolynomial<C::ScalarField>> {

--- a/pasta-tree/src/circuit_fat/prover.rs
+++ b/pasta-tree/src/circuit_fat/prover.rs
@@ -166,6 +166,10 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>>
     type Evaluations = ProofEvals<C::ScalarField>;
     type Instance = G;
 
+    fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
+        <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas)
+    }
+
     fn committed_columns<Fun: Fn(&DensePolynomial<C::ScalarField>) -> WrappedAffine<C>>(
         &self,
         commit: Fun,

--- a/pasta-tree/src/circuit_fat/prover.rs
+++ b/pasta-tree/src/circuit_fat/prover.rs
@@ -7,6 +7,7 @@ use ark_ec::CurveGroup;
 use ark_ff::One;
 use ark_ff::{FftField, PrimeField, Zero};
 use ark_poly::Evaluations;
+use ark_poly::Polynomial;
 use ark_poly::univariate::DensePolynomial;
 use ark_std::{vec, vec::Vec};
 use w3f_pcs::pcs::commitment::WrappedAffine;
@@ -167,7 +168,11 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>>
     type Instance = G;
 
     fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
-        <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas)
+        let chunks =
+            <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas);
+        debug_assert_eq!(chunks.as_ref().unwrap().len(), 4);
+        debug_assert_eq!(chunks.as_ref().unwrap()[3].degree(), 0);
+        chunks
     }
 
     fn committed_columns<Fun: Fn(&DensePolynomial<C::ScalarField>) -> WrappedAffine<C>>(

--- a/pasta-tree/src/circuit_fat/prover.rs
+++ b/pasta-tree/src/circuit_fat/prover.rs
@@ -1,20 +1,16 @@
 use crate::auth_path::node::LevelWitnessWithBlinding;
 use crate::circuit_fat::params::PiopParams;
 use crate::circuit_fat::{ProofComms, ProofEvals};
+use crate::{AffinePoint, CurveModel};
 use ark_ec::AffineRepr;
 use ark_ec::CurveGroup;
-// use ark_ec::short_weierstrass::{Affine as SwAffine, SWCurveConfig};
-use crate::{AffinePoint, CurveModel};
 use ark_ff::One;
 use ark_ff::{FftField, PrimeField, Zero};
-use ark_poly::Evaluations;
-use ark_poly::Polynomial;
 use ark_poly::univariate::DensePolynomial;
+use ark_poly::Evaluations;
 use ark_std::{vec, vec::Vec};
 use w3f_pcs::pcs::commitment::WrappedAffine;
-use w3f_plonk_common::FieldColumn;
 use w3f_plonk_common::domain::Domain;
-use w3f_plonk_common::gadgets::ProverGadget;
 use w3f_plonk_common::gadgets::booleanity::{BitColumn, Booleanity};
 use w3f_plonk_common::gadgets::column_sum::ColumnSumPolys;
 use w3f_plonk_common::gadgets::ec::AffineColumn;
@@ -22,7 +18,9 @@ use w3f_plonk_common::gadgets::ec::CondAdd;
 use w3f_plonk_common::gadgets::equal_cells::CellsEqPolys;
 use w3f_plonk_common::gadgets::fixed_cells::FixedCells;
 use w3f_plonk_common::gadgets::inner_prod_inv::InnerProdInv;
+use w3f_plonk_common::gadgets::ProverGadget;
 use w3f_plonk_common::piop::ProverPiop;
+use w3f_plonk_common::FieldColumn;
 
 pub struct PiopProver<G: AffineRepr<BaseField: FftField>> {
     domain: Domain<G::BaseField>,
@@ -162,11 +160,13 @@ impl<G: CurveModel<BaseField: PrimeField>> PiopProver<AffinePoint<G>> {
     }
 }
 
-impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
-    ProverPiop<C::ScalarField, WrappedAffine<C>> for PiopProver<AffinePoint<G>>
+impl<C: CurveGroup, G: CurveModel<BaseField=C::ScalarField>>
+ProverPiop<C::ScalarField, WrappedAffine<C>> for PiopProver<AffinePoint<G>>
 {
     const N_COLUMNS: usize = 9;
     const N_CONSTRAINTS: usize = 12;
+    const N_QUOTIENT_CHUNKS: usize = 3;
+
     type Commitments = ProofComms<C>;
     type Evaluations = ProofEvals<C::ScalarField>;
     type Instance = AffinePoint<G>;
@@ -227,15 +227,11 @@ impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
                 C::ScalarField::one(),
             )],
         ]
-        .concat()
+            .concat()
     }
 
     fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
-        let chunks =
-            <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas);
-        debug_assert_eq!(chunks.as_ref().unwrap().len(), 4);
-        debug_assert_eq!(chunks.as_ref().unwrap()[3].degree(), 0);
-        chunks
+        <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas)
     }
 
     fn constraints_lin(&self, zeta: &C::ScalarField) -> Vec<DensePolynomial<C::ScalarField>> {
@@ -253,7 +249,7 @@ impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
             // vec![DensePolynomial::zero()],
             vec![DensePolynomial::zero()],
         ]
-        .concat()
+            .concat()
     }
 
     fn domain(&self) -> &Domain<C::ScalarField> {
@@ -271,7 +267,7 @@ mod tests {
     use crate::tests::random_witness;
     use ark_bls12_381::G1Projective;
     use ark_ed_on_bls12_381_bandersnatch::{Fq, Fr, SWAffine};
-    use ark_std::{UniformRand, test_rng};
+    use ark_std::{test_rng, UniformRand};
     use w3f_pcs::pcs::commitment::WrappedAffine;
 
     #[test]

--- a/pasta-tree/src/circuit_tall/params.rs
+++ b/pasta-tree/src/circuit_tall/params.rs
@@ -14,7 +14,7 @@ use w3f_plonk_common::gadgets::booleanity::BitColumn;
 use w3f_plonk_common::gadgets::ec::AffineColumn;
 
 // Hiding Pedersen commitment opened in `2` points.
-pub const ZK_ROWS: usize = 3;
+pub const ZK_ROWS: usize = 2;
 
 // `max_nodes + blinding_bits = domain.capacity - 1`
 // where `1` acounts for the `seed` point.

--- a/pasta-tree/src/circuit_tall/params.rs
+++ b/pasta-tree/src/circuit_tall/params.rs
@@ -13,6 +13,9 @@ use w3f_plonk_common::domain::Domain;
 use w3f_plonk_common::gadgets::booleanity::BitColumn;
 use w3f_plonk_common::gadgets::ec::AffineColumn;
 
+// Hiding Pedersen commitment opened in `2` points.
+pub const ZK_ROWS: usize = 3;
+
 // `max_nodes + blinding_bits = domain.capacity - 1`
 // where `1` acounts for the `seed` point.
 /// Circuit parameters
@@ -94,7 +97,8 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>> CircuitParams<C, 
     }
 
     #[cfg(test)]
-    fn setup(domain: Domain<G::BaseField>, h: G, seed: G) -> Self {
+    fn setup(domain_size: usize, h: G, seed: G) -> Self {
+        let domain = Domain::<G::BaseField>::with_zk_rows(domain_size, ZK_ROWS);
         Self::setup(domain, h, seed)
     }
 }

--- a/pasta-tree/src/circuit_tall/prover.rs
+++ b/pasta-tree/src/circuit_tall/prover.rs
@@ -1,7 +1,6 @@
 use crate::auth_path::node::LevelWitnessWithBlinding;
 use crate::circuit_tall::params::PiopParams;
 use crate::circuit_tall::{ProofComms, ProofEvals};
-// use ark_ec::short_weierstrass::{Affine as SwAffine, SWCurveConfig};
 use crate::{AffinePoint, CurveModel};
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{FftField, One, Zero};
@@ -19,18 +18,6 @@ use w3f_plonk_common::gadgets::ec::CondAdd;
 use w3f_plonk_common::gadgets::fixed_cells::FixedCells;
 use w3f_plonk_common::gadgets::inner_prod::InnerProd;
 use w3f_plonk_common::piop::ProverPiop;
-// struct Witness<F: PrimeField, G: AffineRepr<BaseField=F>> {
-//     // `x` coordinates of all the children of a node. Public input.
-//     // `H, 2H, 4H,...,2^sH` Fixed column.
-//     points: AffineColumn<F, G>,
-//     // `node_x = self.x_coords[self.node_idx]` Private input.
-//     // Bits of the chosen blinding factor. Private input.
-//     bits: BitColumn<F>,
-//     select_part: FieldColumn<F>,
-//     inner_prod_acc: DensePolynomial<F>,
-//     cond_add_acc_x: DensePolynomial<F>,
-//     cond_add_acc_y: DensePolynomial<F>,
-// }
 
 pub struct PiopProver<G: AffineRepr<BaseField: FftField>> {
     domain: Domain<G::BaseField>,
@@ -101,11 +88,13 @@ impl<G: CurveModel<BaseField: FftField>> PiopProver<AffinePoint<G>> {
     }
 }
 
-impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
-    ProverPiop<C::ScalarField, WrappedAffine<C>> for PiopProver<AffinePoint<G>>
+impl<C: CurveGroup, G: CurveModel<BaseField=C::ScalarField>>
+ProverPiop<C::ScalarField, WrappedAffine<C>> for PiopProver<AffinePoint<G>>
 {
     const N_COLUMNS: usize = 7;
     const N_CONSTRAINTS: usize = 7;
+    const N_QUOTIENT_CHUNKS: usize = 3;
+
     type Commitments = ProofComms<C>;
     type Evaluations = ProofEvals<C::ScalarField>;
     type Instance = AffinePoint<G>;
@@ -163,11 +152,7 @@ impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
     }
 
     fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
-        let chunks =
-            <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas);
-        debug_assert_eq!(chunks.as_ref().unwrap().len(), 4);
-        debug_assert_eq!(chunks.as_ref().unwrap()[3].degree(), 0);
-        chunks
+        <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas)
     }
 
     fn constraints_lin(&self, zeta: &C::ScalarField) -> Vec<DensePolynomial<C::ScalarField>> {

--- a/pasta-tree/src/circuit_tall/prover.rs
+++ b/pasta-tree/src/circuit_tall/prover.rs
@@ -88,8 +88,8 @@ impl<G: CurveModel<BaseField: FftField>> PiopProver<AffinePoint<G>> {
     }
 }
 
-impl<C: CurveGroup, G: CurveModel<BaseField=C::ScalarField>>
-ProverPiop<C::ScalarField, WrappedAffine<C>> for PiopProver<AffinePoint<G>>
+impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
+    ProverPiop<C::ScalarField, WrappedAffine<C>> for PiopProver<AffinePoint<G>>
 {
     const N_COLUMNS: usize = 7;
     const N_CONSTRAINTS: usize = 7;

--- a/pasta-tree/src/circuit_tall/prover.rs
+++ b/pasta-tree/src/circuit_tall/prover.rs
@@ -107,6 +107,10 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>>
     type Evaluations = ProofEvals<C::ScalarField>;
     type Instance = G;
 
+    fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
+        <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas)
+    }
+
     fn committed_columns<Fun: Fn(&DensePolynomial<C::ScalarField>) -> WrappedAffine<C>>(
         &self,
         commit: Fun,

--- a/pasta-tree/src/circuit_tall/prover.rs
+++ b/pasta-tree/src/circuit_tall/prover.rs
@@ -110,14 +110,6 @@ impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
     type Evaluations = ProofEvals<C::ScalarField>;
     type Instance = AffinePoint<G>;
 
-    fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
-        let chunks =
-            <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas);
-        debug_assert_eq!(chunks.as_ref().unwrap().len(), 4);
-        debug_assert_eq!(chunks.as_ref().unwrap()[3].degree(), 0);
-        chunks
-    }
-
     fn committed_columns<Fun: Fn(&DensePolynomial<C::ScalarField>) -> WrappedAffine<C>>(
         &self,
         commit: Fun,
@@ -168,6 +160,14 @@ impl<C: CurveGroup, G: CurveModel<BaseField = C::ScalarField>>
 
     fn constraints(&self) -> Vec<Evaluations<C::ScalarField>> {
         self.gadgets.iter().flat_map(|g| g.constraints()).collect()
+    }
+
+    fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
+        let chunks =
+            <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas);
+        debug_assert_eq!(chunks.as_ref().unwrap().len(), 4);
+        debug_assert_eq!(chunks.as_ref().unwrap()[3].degree(), 0);
+        chunks
     }
 
     fn constraints_lin(&self, zeta: &C::ScalarField) -> Vec<DensePolynomial<C::ScalarField>> {

--- a/pasta-tree/src/circuit_tall/prover.rs
+++ b/pasta-tree/src/circuit_tall/prover.rs
@@ -108,7 +108,11 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>>
     type Instance = G;
 
     fn quotient(&self, alphas: &[C::ScalarField]) -> Option<Vec<DensePolynomial<C::ScalarField>>> {
-        <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas)
+        let chunks =
+            <Self as ProverPiop<C::ScalarField, WrappedAffine<C>>>::_quotient_chunks(self, alphas);
+        debug_assert_eq!(chunks.as_ref().unwrap().len(), 4);
+        debug_assert_eq!(chunks.as_ref().unwrap()[3].degree(), 0);
+        chunks
     }
 
     fn committed_columns<Fun: Fn(&DensePolynomial<C::ScalarField>) -> WrappedAffine<C>>(

--- a/pasta-tree/src/lib.rs
+++ b/pasta-tree/src/lib.rs
@@ -10,8 +10,6 @@ use w3f_pcs::pcs::PCS;
 use w3f_pcs::pcs::commitment::WrappedAffine;
 use w3f_pcs::pcs::ipa::hiding::HidingIpa;
 use w3f_pcs::shplonk::AggregateProof;
-#[cfg(test)]
-use w3f_plonk_common::domain::Domain;
 use w3f_plonk_common::piop::{ProverPiop, VerifierPiop};
 use w3f_plonk_common::{ColumnsCommited, ColumnsEvaluated, FieldColumn};
 
@@ -58,7 +56,7 @@ pub trait CircuitParams<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>
 
     #[cfg(test)] // an "application" runs usually a single circuit
     /// `h` is the pedersen blinding base (from the opposite side) to prove `C' = Ci + rH`
-    fn setup(domain: Domain<C::ScalarField>, h: G, seed: G) -> Self;
+    fn setup(domain_size: usize, h: G, seed: G) -> Self;
 }
 
 pub struct CycleSideParams<
@@ -224,10 +222,8 @@ mod tests {
             let setup_degree = 3 * domain_size;
             let c0_pcs_params = HidingIpa::<C0>::setup(setup_degree, rng);
             let c1_pcs_params = HidingIpa::<C1>::setup(setup_degree, rng);
-            let c0_domain = Domain::<C0::ScalarField>::with_zk_rows(domain_size, 3);
-            let c0_piop_params = P0::setup(c0_domain, c1_pcs_params.h, C1::Affine::rand(rng));
-            let c1_domain = Domain::<C1::ScalarField>::with_zk_rows(domain_size, 3);
-            let c1_piop_params = P1::setup(c1_domain, c0_pcs_params.h, C0::Affine::rand(rng));
+            let c0_piop_params = P0::setup(domain_size, c1_pcs_params.h, C1::Affine::rand(rng));
+            let c1_piop_params = P1::setup(domain_size, c0_pcs_params.h, C0::Affine::rand(rng));
             Self {
                 c0_params: CycleSideParams {
                     pcs_params: c0_pcs_params,

--- a/pasta-tree/src/lib.rs
+++ b/pasta-tree/src/lib.rs
@@ -260,11 +260,11 @@ mod tests {
             ark_vesta::Projective,
             CircuitParamsFat<ark_vesta::Affine>,
             CircuitParamsFat<ark_pallas::Affine>,
-        >(8, 4);
+        >(8, 2);
     }
 
-    // cargo test test_bench_curve_tree --release --features="print-trace" -- --show-output
-    // cargo test test_bench_curve_tree --release --features="print-trace parallel" -- --show-output
+    // cargo test test_bench_curve_tree --release --features="print-trace" -- --show-output --ignored
+    // cargo test test_bench_curve_tree --release --features="print-trace parallel" -- --show-output --ignored
     #[test]
     #[ignore]
     fn test_bench_curve_tree() {
@@ -278,25 +278,25 @@ mod tests {
         >(log_n, h);
         println!();
 
-        let (log_n, h) = (9, 2);
-        println!("n = {}, height = {h}, TALL", 1 << log_n);
-        _test_proof::<
-            ark_pallas::Projective,
-            ark_vesta::Projective,
-            CircuitParamsTall<ark_vesta::Affine>,
-            CircuitParamsTall<ark_pallas::Affine>,
-        >(log_n, h);
-        println!();
+        // let (log_n, h) = (9, 2);
+        // println!("n = {}, height = {h}, TALL", 1 << log_n);
+        // _test_proof::<
+        //     ark_pallas::Projective,
+        //     ark_vesta::Projective,
+        //     CircuitParamsTall<ark_vesta::Affine>,
+        //     CircuitParamsTall<ark_pallas::Affine>,
+        // >(log_n, h);
+        // println!();
 
-        let (log_n, h) = (10, 2);
-        println!("n = {}, height = {h}, TALL", 1 << log_n);
-        _test_proof::<
-            ark_pallas::Projective,
-            ark_vesta::Projective,
-            CircuitParamsTall<ark_vesta::Affine>,
-            CircuitParamsTall<ark_pallas::Affine>,
-        >(log_n, h);
-        println!();
+        // let (log_n, h) = (10, 2);
+        // println!("n = {}, height = {h}, TALL", 1 << log_n);
+        // _test_proof::<
+        //     ark_pallas::Projective,
+        //     ark_vesta::Projective,
+        //     CircuitParamsTall<ark_vesta::Affine>,
+        //     CircuitParamsTall<ark_pallas::Affine>,
+        // >(log_n, h);
+        // println!();
 
         let (log_n, h) = (8, 4);
         println!("n = {}, height = {h}, FAT", 1 << log_n);
@@ -308,7 +308,7 @@ mod tests {
         >(log_n, h);
         println!();
 
-        let (log_n, h) = (9, 4);
+        let (log_n, h) = (10, 4);
         println!("n = {}, height = {h}, TALL", 1 << log_n);
         _test_proof::<
             ark_pallas::Projective,

--- a/pasta-tree/src/lib.rs
+++ b/pasta-tree/src/lib.rs
@@ -232,8 +232,10 @@ mod tests {
             let setup_degree = 3 * domain_size;
             let c0_pcs_params = HidingIpa::<ProjectivePoint<C0>>::setup(setup_degree, rng);
             let c1_pcs_params = HidingIpa::<ProjectivePoint<C1>>::setup(setup_degree, rng);
-            let c0_piop_params = P0::setup(domain_size, c1_pcs_params.h, AffinePoint::<C1>::rand(rng));
-            let c1_piop_params = P1::setup(domain_size, c0_pcs_params.h, AffinePoint::<C0>::rand(rng));
+            let c0_piop_params =
+                P0::setup(domain_size, c1_pcs_params.h, AffinePoint::<C1>::rand(rng));
+            let c1_piop_params =
+                P1::setup(domain_size, c0_pcs_params.h, AffinePoint::<C0>::rand(rng));
             Self {
                 c0_params: CycleSideParams {
                     pcs_params: c0_pcs_params,
@@ -252,8 +254,8 @@ mod tests {
     #[test]
     fn test_circuit_tall() {
         _test_proof::<
-            ark_pallas::Projective,
-            ark_vesta::Projective,
+            PallasConfig,
+            VestaConfig,
             CircuitParamsTall<ark_vesta::Affine>,
             CircuitParamsTall<ark_pallas::Affine>,
         >(9, 2);
@@ -262,8 +264,8 @@ mod tests {
     #[test]
     fn test_circuit_fat() {
         _test_proof::<
-            ark_pallas::Projective,
-            ark_vesta::Projective,
+            PallasConfig,
+            VestaConfig,
             CircuitParamsFat<ark_vesta::Affine>,
             CircuitParamsFat<ark_pallas::Affine>,
         >(8, 2);

--- a/pasta-tree/src/lib.rs
+++ b/pasta-tree/src/lib.rs
@@ -243,6 +243,26 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_circuit_tall() {
+        _test_proof::<
+            ark_pallas::Projective,
+            ark_vesta::Projective,
+            CircuitParamsTall<ark_vesta::Affine>,
+            CircuitParamsTall<ark_pallas::Affine>,
+        >(9, 2);
+    }
+
+    #[test]
+    fn test_circuit_fat() {
+        _test_proof::<
+            ark_pallas::Projective,
+            ark_vesta::Projective,
+            CircuitParamsFat<ark_vesta::Affine>,
+            CircuitParamsFat<ark_pallas::Affine>,
+        >(8, 4);
+    }
+
     // cargo test test_bench_curve_tree --release --features="print-trace" -- --show-output
     // cargo test test_bench_curve_tree --release --features="print-trace parallel" -- --show-output
     #[test]

--- a/pasta-tree/src/prover.rs
+++ b/pasta-tree/src/prover.rs
@@ -56,15 +56,22 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>, P: CircuitParams<
         witness: Vec<LevelWitnessWithBlinding<G>>,
         rng: &mut R,
     ) -> CycleSideProof<C, G, P> {
-        let curve_name = &std::any::type_name::<C>()[70..];
+        let curve_name = &std::any::type_name::<C>()[53..];
         // println!("\n\nprover {curve_name}\nchildren={blinded_path:?}\n");
+        let n_levels = witness.len(); // number of tree levels on this side
+        debug_assert_eq!(blinded_path.len(), n_levels);
+        let mut piop_proofs = Vec::with_capacity(n_levels);
 
-        debug_assert_eq!(blinded_path.len(), witness.len());
-        let n_polys = P::VerifierCircuit::N_COLUMNS + 2; // plus the quotient and the linearization polys
-        let mut piop_proofs = Vec::with_capacity(witness.len());
-        let mut polys = Vec::with_capacity(witness.len() * n_polys);
-        let mut coords = Vec::with_capacity(witness.len() * n_polys);
-        let mut bfs = Vec::with_capacity(witness.len() * n_polys);
+        // per tree level
+        let n_columns = P::VerifierCircuit::N_COLUMNS;
+        let n_to_commit = n_columns + 4; // plus the quotient chunks
+        let n_to_open = n_columns + 2; // plus the (folded) quotient (chunks) and the linearization polynomial
+
+        // per side
+        let n_openings = n_levels * n_to_open;
+        let mut polys_to_open = Vec::with_capacity(n_openings);
+        let mut at_coords = Vec::with_capacity(n_openings);
+        let mut with_bfs = Vec::with_capacity(n_openings);
 
         let plonk_prover = PlonkProver::<C::ScalarField, HidingIpa<C>, _>::init(
             self.pcs_params.ck(),
@@ -73,11 +80,10 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>, P: CircuitParams<
         );
 
         let t_commit_side = start_timer!(|| format!(
-            "Committing to {} polynomials at {curve_name}",
-            witness.len() * (n_polys - 1)
+            "Committing {n_levels} x {n_to_commit} polynomials to {curve_name}"
         ));
         for (level, blinded_node) in witness.into_iter().zip(blinded_path.into_iter()) {
-            let t_commit_level = start_timer!(|| format!("Committing to {} polynomials", n_polys));
+            // let t_commit_level = start_timer!(|| format!("Committing {n_to_commit} polynomials"));
             let piop: P::ProverCircuit =
                 <P as CircuitParams<C, G>>::prover_circuit(&self.piop_params, level.clone());
             let result =
@@ -98,31 +104,29 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>, P: CircuitParams<
             //     polys_at_zeta[polys_at_zeta.len() - 1].evaluate(&zeta)
             // );
 
-            coords.extend(vec![BTreeSet::from([zeta]); polys_at_zeta.len()]);
-            polys.extend(polys_at_zeta);
-            coords.extend(vec![
+            at_coords.extend(vec![BTreeSet::from([zeta]); polys_at_zeta.len()]);
+            polys_to_open.extend(polys_at_zeta);
+            at_coords.extend(vec![
                 BTreeSet::from([zeta_omega]);
                 polys_at_zeta_omega.len()
             ]);
-            polys.extend(polys_at_zeta_omega);
-            bfs.push(level.parent_bf);
-            bfs.resize(polys.len(), C::ScalarField::zero());
-            end_timer!(t_commit_level);
+            polys_to_open.extend(polys_at_zeta_omega);
+            with_bfs.push(level.parent_bf);
+            with_bfs.resize(polys_to_open.len(), C::ScalarField::zero());
+            // end_timer!(t_commit_level);
         }
         end_timer!(t_commit_side);
 
-        let max_degree = polys.iter().map(|p| p.degree()).max().unwrap();
         let t_open = start_timer!(|| format!(
-            "Opening {} polynomials with maximal degree-{}",
-            polys.len(),
-            max_degree
+            "Opening {n_openings} polynomials, max_degree = {}",
+            polys_to_open.iter().map(|p| p.degree()).max().unwrap()
         ));
         let todo = Coeffs(C::ScalarField::rand(rng), C::ScalarField::rand(rng));
         let pcs_proof = Shplonk::<C::ScalarField, HidingIpa<C>>::open_many_hiding(
             &self.pcs_params,
-            &polys,
-            &bfs,
-            &coords,
+            &polys_to_open,
+            &with_bfs,
+            &at_coords,
             &mut todo.clone(),
             rng,
         );

--- a/pasta-tree/src/verifier.rs
+++ b/pasta-tree/src/verifier.rs
@@ -48,20 +48,25 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>, P: CircuitParams<
         parents: Vec<C::Affine>,
         side_proof: CycleSideProof<C, G, P>,
     ) -> bool {
-        // let mut s = std::any::type_name::<C>();
-        // s = &s[65..s.len()];
-        // println!("\n\nverifier {s}\nchildren={children:?}\nparents={parents:?}\n");
+        // let curve_name = &std::any::type_name::<C>()[53..];
+        // println!("\n\nverifier {curve_name}\nchildren={children:?}\nparents={parents:?}\n");
+
+        // number of tree levels on this side
+        let n_levels = side_proof.piop_proofs.len();
+        // per tree level
+        let n_to_open = P::VerifierCircuit::N_COLUMNS + 2; // plus the (folded) quotient (chunks) and the linearization polynomial
+        // per side
+        let n_openings = n_levels * n_to_open;
+
+        let mut polys_to_open = Vec::with_capacity(n_openings);
+        let mut at_coords = Vec::with_capacity(n_openings);
+        let mut to_values = Vec::with_capacity(n_openings);
 
         let plonk_verifier: PlonkVerifier<C::ScalarField, HidingIpa<C>, _> = PlonkVerifier::init(
             self.pcs_params.vk(),
-            &(),
+            &(), // TODO
             ArkTranscript::new(b"pasta-tree-level-proof"),
         );
-
-        let n_polys = P::VerifierCircuit::N_COLUMNS + 2; // plus the quotient and the linearization polys
-        let mut polys = Vec::with_capacity(side_proof.piop_proofs.len() * n_polys);
-        let mut coords = Vec::with_capacity(side_proof.piop_proofs.len() * n_polys);
-        let mut vals = Vec::with_capacity(side_proof.piop_proofs.len() * n_polys);
 
         //TODO: precompute
         let fixed_cols = self.commit_fixed_columns();
@@ -99,21 +104,21 @@ impl<C: CurveGroup, G: AffineRepr<BaseField = C::ScalarField>, P: CircuitParams<
             //     vals_at_zeta[vals_at_zeta.len() - 1]
             // );
 
-            coords.extend(vec![vec![zeta]; open_at_zeta.len()]);
-            polys.extend(open_at_zeta);
-            coords.extend(vec![vec![zeta_omega]; open_at_zeta_omega.len()]);
-            polys.extend(open_at_zeta_omega);
-            vals.extend(vals_at_zeta.into_iter().map(|v| vec![v]));
-            vals.extend(vals_at_zeta_omega.into_iter().map(|v| vec![v]));
+            at_coords.extend(vec![vec![zeta]; open_at_zeta.len()]);
+            polys_to_open.extend(open_at_zeta);
+            at_coords.extend(vec![vec![zeta_omega]; open_at_zeta_omega.len()]);
+            polys_to_open.extend(open_at_zeta_omega);
+            to_values.extend(vals_at_zeta.into_iter().map(|v| vec![v]));
+            to_values.extend(vals_at_zeta_omega.into_iter().map(|v| vec![v]));
         }
 
         let mut todo = side_proof.todo;
         let valid = Shplonk::<C::ScalarField, HidingIpa<C>>::verify_many(
             &self.pcs_params.vk(),
-            &polys,
+            &polys_to_open,
             side_proof.pcs_proof,
-            &coords,
-            &vals,
+            &at_coords,
+            &to_values,
             &mut todo,
         );
         valid

--- a/w3f-plonk-common/src/domain.rs
+++ b/w3f-plonk-common/src/domain.rs
@@ -205,6 +205,7 @@ pub struct EvaluatedDomain<F: FftField> {
     pub l_first: F,
     pub l_last: F,
     pub vanishing_polynomial_inv: F,
+    pub z_n: F, // z^N
 }
 
 impl<F: FftField> EvaluatedDomain<F> {
@@ -243,6 +244,7 @@ impl<F: FftField> EvaluatedDomain<F> {
             l_first,
             l_last,
             vanishing_polynomial_inv,
+            z_n,
         }
     }
 

--- a/w3f-plonk-common/src/kzg_acc.rs
+++ b/w3f-plonk-common/src/kzg_acc.rs
@@ -1,6 +1,6 @@
 use crate::piop::VerifierPiop;
 use crate::verifier::Challenges;
-use crate::{ColumnsCommited, ColumnsEvaluated, Proof};
+use crate::{q_chunking, ColumnsCommited, ColumnsEvaluated, Proof};
 use ark_ec::pairing::Pairing;
 use ark_ec::{CurveGroup, VariableBaseMSM};
 use ark_ff::{PrimeField, Zero};
@@ -93,8 +93,8 @@ impl<E: Pairing> KzgAccumulator<E> {
         let zeta_omega = zeta * piop.domain_evaluated().omega();
         let lin_comm = piop.lin_poly_commitment(&challenges.alphas);
 
-        // Openning at `z`
-        // TODO: try to get rid of the commitment wrapper in flonk
+        // Openning at `z`. Columns and the quotient are aggregated using `nu`s.
+        let mut r_nus = challenges.nus.iter().map(|nu| r * nu);
         self.acc_points.extend(
             piop.precommitted_columns()
                 .iter()
@@ -109,9 +109,19 @@ impl<E: Pairing> KzgAccumulator<E> {
                 .map(|c| c.0)
                 .collect::<Vec<_>>(),
         );
-        self.acc_points.push(proof.quotient_commitment.clone().0);
         self.acc_scalars
-            .extend(challenges.nus.iter().map(|nu| *nu * r).collect::<Vec<_>>()); // numbers should match here
+            .extend(r_nus.by_ref().take(Piop::N_COLUMNS));
+
+        // quotient (chunks) at `z`
+        let r_nu_last = r_nus.next().unwrap();
+        let z_n = piop.domain_evaluated().z_n;
+        self.acc_points
+            .extend(proof.quotient_chunks.iter().map(|c| c.0));
+        self.acc_scalars.extend(
+            q_chunking::chunk_coeffs(z_n)
+                .map(|c| r_nu_last * c)
+                .take(proof.quotient_chunks.len()),
+        );
 
         self.acc_points.push(proof.agg_at_zeta_proof);
         self.acc_scalars.push(zeta * r);

--- a/w3f-plonk-common/src/lib.rs
+++ b/w3f-plonk-common/src/lib.rs
@@ -14,10 +14,10 @@ pub mod gadgets;
 pub mod kzg_acc;
 pub mod piop;
 pub mod prover;
+mod q_chunking;
 pub mod test_helpers;
 pub mod transcript;
 pub mod verifier;
-mod q_chunking;
 
 pub trait Column<F: FftField, V> {
     fn domain(&self) -> GeneralEvaluationDomain<F>;

--- a/w3f-plonk-common/src/lib.rs
+++ b/w3f-plonk-common/src/lib.rs
@@ -14,7 +14,7 @@ pub mod gadgets;
 pub mod kzg_acc;
 pub mod piop;
 pub mod prover;
-mod q_chunking;
+pub mod q_chunking;
 pub mod test_helpers;
 pub mod transcript;
 pub mod verifier;

--- a/w3f-plonk-common/src/lib.rs
+++ b/w3f-plonk-common/src/lib.rs
@@ -17,6 +17,7 @@ pub mod prover;
 pub mod test_helpers;
 pub mod transcript;
 pub mod verifier;
+mod q_chunking;
 
 pub trait Column<F: FftField, V> {
     fn domain(&self) -> GeneralEvaluationDomain<F>;
@@ -103,7 +104,7 @@ where
 {
     pub column_commitments: Commitments,
     pub columns_at_zeta: Evaluations,
-    pub quotient_commitment: CS::C,
+    pub quotient_chunks: Vec<CS::C>,
     pub lin_at_zeta_omega: F,
     pub agg_at_zeta_proof: CS::Proof,
     pub lin_at_zeta_omega_proof: CS::Proof,
@@ -120,7 +121,7 @@ where
 {
     pub column_commitments: Commitments,
     pub columns_at_zeta: Evaluations,
-    pub quotient_commitment: C,
+    pub quotient_chunks: Vec<C>,
     pub lin_at_zeta_omega: F,
 }
 
@@ -135,7 +136,7 @@ where
         PiopProof {
             column_commitments: self.column_commitments.clone(),
             columns_at_zeta: self.columns_at_zeta.clone(),
-            quotient_commitment: self.quotient_commitment.clone(),
+            quotient_chunks: self.quotient_chunks.clone(),
             lin_at_zeta_omega: self.lin_at_zeta_omega,
         }
     }

--- a/w3f-plonk-common/src/piop.rs
+++ b/w3f-plonk-common/src/piop.rs
@@ -1,12 +1,12 @@
+use crate::domain::{Domain, EvaluatedDomain};
+use crate::{q_chunking, ColumnsCommited, ColumnsEvaluated};
 use ark_ff::{FftField, PrimeField};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::Evaluations;
+use ark_poly::Polynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::Vec;
 use w3f_pcs::pcs::Commitment;
-
-use crate::domain::{Domain, EvaluatedDomain};
-use crate::{ColumnsCommited, ColumnsEvaluated};
 
 pub trait ProverPiop<F: PrimeField, C: Commitment<F>> {
     const N_COLUMNS: usize;
@@ -32,11 +32,25 @@ pub trait ProverPiop<F: PrimeField, C: Commitment<F>> {
     // Constraint polynomials in evaluation form.
     fn constraints(&self) -> Vec<Evaluations<F>>;
 
-    fn quotient_chunks(&self, alphas: &[F]) -> Option<Vec<DensePolynomial<F>>> {
-        self.compute_quotient(alphas).map(|q| vec![q])
+    fn _quotient_chunks(&self, alphas: &[F]) -> Option<Vec<DensePolynomial<F>>> {
+        let q = Self::_compute_quotient(self, alphas);
+        q.map(|q| {
+            let q_deg = q.degree();
+            let q_chunks = q_chunking::chunk_quotient(q, self.domain().domain_size());
+            println!(
+                "Chunking deg {} polynomial into {} chunks",
+                q_deg,
+                q_chunks.len()
+            );
+            q_chunks
+        })
     }
 
-    fn compute_quotient(&self, alphas: &[F]) -> Option<DensePolynomial<F>> {
+    fn quotient(&self, alphas: &[F]) -> Option<Vec<DensePolynomial<F>>> {
+        self._compute_quotient(alphas).map(|q| vec![q])
+    }
+
+    fn _compute_quotient(&self, alphas: &[F]) -> Option<DensePolynomial<F>> {
         let constraints = self.constraints();
         // Aggregate constraint polynomials in evaluation form...
         let agg_constraint = aggregate_evaluations(&constraints, &alphas);

--- a/w3f-plonk-common/src/piop.rs
+++ b/w3f-plonk-common/src/piop.rs
@@ -5,6 +5,7 @@ use ark_poly::univariate::DensePolynomial;
 use ark_poly::Evaluations;
 use ark_poly::Polynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::vec;
 use ark_std::vec::Vec;
 use w3f_pcs::pcs::Commitment;
 
@@ -35,11 +36,12 @@ pub trait ProverPiop<F: PrimeField, C: Commitment<F>> {
     fn _quotient_chunks(&self, alphas: &[F]) -> Option<Vec<DensePolynomial<F>>> {
         let q = Self::_compute_quotient(self, alphas);
         q.map(|q| {
-            let q_deg = q.degree();
+            let _q_deg = q.degree();
             let q_chunks = q_chunking::chunk_quotient(q, self.domain().domain_size());
+            #[cfg(feature = "std")]
             println!(
                 "Chunking deg {} polynomial into {} chunks",
-                q_deg,
+                _q_deg,
                 q_chunks.len()
             );
             q_chunks

--- a/w3f-plonk-common/src/piop.rs
+++ b/w3f-plonk-common/src/piop.rs
@@ -12,6 +12,7 @@ use w3f_pcs::pcs::Commitment;
 pub trait ProverPiop<F: PrimeField, C: Commitment<F>> {
     const N_COLUMNS: usize;
     const N_CONSTRAINTS: usize;
+    const N_QUOTIENT_CHUNKS: usize = 1;
 
     type Commitments: ColumnsCommited<F, C>;
     type Evaluations: ColumnsEvaluated<F>;
@@ -38,6 +39,7 @@ pub trait ProverPiop<F: PrimeField, C: Commitment<F>> {
         q.map(|q| {
             let _q_deg = q.degree();
             let q_chunks = q_chunking::chunk_quotient(q, self.domain().domain_size());
+            debug_assert_eq!(q_chunks.len(), Self::N_QUOTIENT_CHUNKS);
             #[cfg(feature = "std")]
             println!(
                 "Chunking deg {} polynomial into {} chunks",

--- a/w3f-plonk-common/src/piop.rs
+++ b/w3f-plonk-common/src/piop.rs
@@ -33,7 +33,7 @@ pub trait ProverPiop<F: PrimeField, C: Commitment<F>> {
     fn constraints(&self) -> Vec<Evaluations<F>>;
 
     fn quotient_chunks(&self, alphas: &[F]) -> Option<Vec<DensePolynomial<F>>> {
-        self.compute_quotient(alphas).map(|q|vec![q])
+        self.compute_quotient(alphas).map(|q| vec![q])
     }
 
     fn compute_quotient(&self, alphas: &[F]) -> Option<DensePolynomial<F>> {

--- a/w3f-plonk-common/src/piop.rs
+++ b/w3f-plonk-common/src/piop.rs
@@ -32,6 +32,10 @@ pub trait ProverPiop<F: PrimeField, C: Commitment<F>> {
     // Constraint polynomials in evaluation form.
     fn constraints(&self) -> Vec<Evaluations<F>>;
 
+    fn quotient_chunks(&self, alphas: &[F]) -> Option<Vec<DensePolynomial<F>>> {
+        self.compute_quotient(alphas).map(|q|vec![q])
+    }
+
     fn compute_quotient(&self, alphas: &[F]) -> Option<DensePolynomial<F>> {
         let constraints = self.constraints();
         // Aggregate constraint polynomials in evaluation form...

--- a/w3f-plonk-common/src/prover.rs
+++ b/w3f-plonk-common/src/prover.rs
@@ -69,15 +69,21 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
         end_timer!(t_commit_cols);
 
         // ROUND 2
-        let alphas = transcript.get_constraints_aggregation_coeffs(P::N_CONSTRAINTS);
-        let quotient_poly = piop.compute_quotient(&alphas).unwrap();
-        let t_commit_q = start_timer!(|| format!(
-            "Committing to the degree-{} quotient",
-            quotient_poly.degree()
-        ));
         // The prover commits to the quotient polynomial...
-        let quotient_commitment = CS::commit(&self.pcs_ck, &quotient_poly).unwrap();
-        transcript.add_quotient_commitment(&quotient_commitment);
+        let alphas = transcript.get_constraints_aggregation_coeffs(P::N_CONSTRAINTS);
+        let quotient_chunks = piop.quotient_chunks(&alphas).unwrap();
+        let t_commit_q = start_timer!(|| format!(
+            "Committing to {} degree-{} quotient chunks", quotient_chunks.len(),
+            quotient_chunks[0].degree()
+        ));
+        let quotient_chunks_committed: Vec<_> = quotient_chunks.iter()
+            .map(|qi| CS::commit(&self.pcs_ck, qi).unwrap())
+            .collect();
+        for qi_committed in quotient_chunks_committed.iter() {
+            transcript.add_quotient_commitment(&qi_committed);
+        }
+        // let quotient_commitment = CS::commit(&self.pcs_ck, &quotient_poly).unwrap();
+        // transcript.add_quotient_commitment(&quotient_commitment);
         end_timer!(t_commit_q);
 
         // and receives the evaluation point in response
@@ -94,11 +100,11 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
         transcript.add_evaluations(&columns_at_zeta, &lin_at_zeta_omega);
         let piop_proof = PiopProof {
             column_commitments,
-            quotient_commitment,
+            quotient_chunks: quotient_chunks_committed,
             columns_at_zeta,
             lin_at_zeta_omega,
         };
-        let polys_at_zeta = [columns_to_open, vec![quotient_poly]].concat();
+        let polys_at_zeta = [columns_to_open, quotient_chunks].concat();
         let pcs_openings = PcsOpeningAt2Points {
             polys_at_zeta,
             polys_at_zeta_omega: vec![lin],
@@ -122,7 +128,7 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
         let lin = &polys_at_zeta_omega[0];
         let PiopProof {
             column_commitments,
-            quotient_commitment,
+            quotient_chunks: quotient_commitment,
             columns_at_zeta,
             lin_at_zeta_omega,
         } = piop_proof;
@@ -137,7 +143,7 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
         end_timer!(_t_open_zeta_omega);
         Proof {
             column_commitments,
-            quotient_commitment,
+            quotient_chunks: quotient_commitment,
             columns_at_zeta,
             lin_at_zeta_omega,
             agg_at_zeta_proof,

--- a/w3f-plonk-common/src/prover.rs
+++ b/w3f-plonk-common/src/prover.rs
@@ -11,7 +11,7 @@ use w3f_pcs::pcs::PCS;
 
 use crate::piop::ProverPiop;
 use crate::transcript::PlonkTranscript;
-use crate::{PiopProof, Proof};
+use crate::{q_chunking, PiopProof, Proof};
 
 pub struct PlonkProver<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> {
     // Polynomial commitment scheme committer's key.
@@ -92,6 +92,8 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
 
         // ROUND 3
         let zeta = transcript.get_evaluation_point();
+        let z_n = zeta.pow([piop.domain().domain_size() as u64]);
+        let q_folded = q_chunking::fold_quotient_chunks(&quotient_chunks, z_n);
         let columns_to_open = piop.columns();
         let columns_at_zeta = piop.columns_evaluated(&zeta);
         let constraint_polys_linearized = piop.constraints_lin(&zeta);
@@ -106,7 +108,7 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
             columns_at_zeta,
             lin_at_zeta_omega,
         };
-        let polys_at_zeta = [columns_to_open, quotient_chunks].concat();
+        let polys_at_zeta = [columns_to_open, vec![q_folded]].concat();
         let pcs_openings = PcsOpeningAt2Points {
             polys_at_zeta,
             polys_at_zeta_omega: vec![lin],

--- a/w3f-plonk-common/src/prover.rs
+++ b/w3f-plonk-common/src/prover.rs
@@ -71,7 +71,7 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
         // ROUND 2
         // The prover commits to the quotient polynomial...
         let alphas = transcript.get_constraints_aggregation_coeffs(P::N_CONSTRAINTS);
-        let quotient_chunks = piop.quotient_chunks(&alphas).unwrap();
+        let quotient_chunks = piop.quotient(&alphas).unwrap();
         let t_commit_q = start_timer!(|| format!(
             "Committing to {} degree-{} quotient chunks",
             quotient_chunks.len(),

--- a/w3f-plonk-common/src/prover.rs
+++ b/w3f-plonk-common/src/prover.rs
@@ -73,10 +73,12 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkProver<F, CS, T>
         let alphas = transcript.get_constraints_aggregation_coeffs(P::N_CONSTRAINTS);
         let quotient_chunks = piop.quotient_chunks(&alphas).unwrap();
         let t_commit_q = start_timer!(|| format!(
-            "Committing to {} degree-{} quotient chunks", quotient_chunks.len(),
+            "Committing to {} degree-{} quotient chunks",
+            quotient_chunks.len(),
             quotient_chunks[0].degree()
         ));
-        let quotient_chunks_committed: Vec<_> = quotient_chunks.iter()
+        let quotient_chunks_committed: Vec<_> = quotient_chunks
+            .iter()
             .map(|qi| CS::commit(&self.pcs_ck, qi).unwrap())
             .collect();
         for qi_committed in quotient_chunks_committed.iter() {

--- a/w3f-plonk-common/src/q_chunking.rs
+++ b/w3f-plonk-common/src/q_chunking.rs
@@ -4,14 +4,14 @@ use ark_poly::DenseUVPolynomial;
 use w3f_pcs::pcs::Commitment;
 use w3f_pcs::utils;
 
-fn chunk_quotient<F: Field>(q: DensePolynomial<F>, n: usize) -> Vec<DensePolynomial<F>> {
+pub fn chunk_quotient<F: Field>(q: DensePolynomial<F>, n: usize) -> Vec<DensePolynomial<F>> {
     q.coeffs
         .chunks(n)
         .map(|coeffs| DensePolynomial::from_coefficients_slice(coeffs))
         .collect()
 }
 
-fn fold_quotient_chunks<F: Field>(chunks: &[DensePolynomial<F>], z_to_n: F) -> DensePolynomial<F> {
+pub fn fold_quotient_chunks<F: Field>(chunks: &[DensePolynomial<F>], z_to_n: F) -> DensePolynomial<F> {
     chunks
         .iter()
         .zip(utils::powers(z_to_n))
@@ -20,7 +20,7 @@ fn fold_quotient_chunks<F: Field>(chunks: &[DensePolynomial<F>], z_to_n: F) -> D
         .unwrap()
 }
 
-fn quotient_commitment<F: PrimeField, C: Commitment<F>>(chunks: &[C], z_to_n: F) -> C {
+pub fn compose_quotient<F: PrimeField, C: Commitment<F>>(chunks: &[C], z_to_n: F) -> C {
     chunks
         .iter()
         .zip(utils::powers(z_to_n))

--- a/w3f-plonk-common/src/q_chunking.rs
+++ b/w3f-plonk-common/src/q_chunking.rs
@@ -11,13 +11,17 @@ pub fn chunk_quotient<F: Field>(q: DensePolynomial<F>, n: usize) -> Vec<DensePol
         .collect()
 }
 
+pub fn chunk_coeffs<F: Field>(z_to_n: F) -> impl Iterator<Item = F> {
+    utils::powers(z_to_n)
+}
+
 pub fn fold_quotient_chunks<F: Field>(
     chunks: &[DensePolynomial<F>],
     z_to_n: F,
 ) -> DensePolynomial<F> {
     chunks
         .iter()
-        .zip(utils::powers(z_to_n))
+        .zip(chunk_coeffs(z_to_n))
         .map(|(chunk, coeff)| chunk * coeff)
         .reduce(|acc, new| acc + new)
         .unwrap()
@@ -26,7 +30,7 @@ pub fn fold_quotient_chunks<F: Field>(
 pub fn compose_quotient<F: PrimeField, C: Commitment<F>>(chunks: &[C], z_to_n: F) -> C {
     chunks
         .iter()
-        .zip(utils::powers(z_to_n))
+        .zip(chunk_coeffs(z_to_n))
         .map(|(chunk, coeff)| chunk.mul(coeff))
         .sum()
 }

--- a/w3f-plonk-common/src/q_chunking.rs
+++ b/w3f-plonk-common/src/q_chunking.rs
@@ -1,0 +1,32 @@
+use ark_ff::{Field, PrimeField};
+use ark_poly::DenseUVPolynomial;
+use ark_poly::univariate::DensePolynomial;
+use w3f_pcs::pcs::Commitment;
+use w3f_pcs::utils;
+
+fn chunk_quotient<F: Field>(q: DensePolynomial<F>, n: usize) -> Vec<DensePolynomial<F>> {
+    q.coeffs
+        .chunks(n)
+        .map(|coeffs| DensePolynomial::from_coefficients_slice(coeffs))
+        .collect()
+}
+
+fn fold_quotient_chunks<F: Field>(chunks: &[DensePolynomial<F>], z_to_n: F) -> DensePolynomial<F> {
+    chunks.iter()
+        .zip(utils::powers(z_to_n))
+        .map(|(chunk, coeff)| chunk * coeff)
+        .reduce(|acc, new| acc + new)
+        .unwrap()
+}
+
+fn quotient_commitment<F: PrimeField, C: Commitment<F>>(chunks: &[C], z_to_n: F) -> C {
+    chunks.iter()
+        .zip(utils::powers(z_to_n))
+        .map(|(chunk, coeff)| chunk.mul(coeff))
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+
+}

--- a/w3f-plonk-common/src/q_chunking.rs
+++ b/w3f-plonk-common/src/q_chunking.rs
@@ -1,6 +1,7 @@
 use ark_ff::{Field, PrimeField};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::DenseUVPolynomial;
+use ark_std::vec::Vec;
 use w3f_pcs::pcs::Commitment;
 use w3f_pcs::utils;
 

--- a/w3f-plonk-common/src/q_chunking.rs
+++ b/w3f-plonk-common/src/q_chunking.rs
@@ -1,6 +1,6 @@
 use ark_ff::{Field, PrimeField};
-use ark_poly::DenseUVPolynomial;
 use ark_poly::univariate::DensePolynomial;
+use ark_poly::DenseUVPolynomial;
 use w3f_pcs::pcs::Commitment;
 use w3f_pcs::utils;
 
@@ -12,7 +12,8 @@ fn chunk_quotient<F: Field>(q: DensePolynomial<F>, n: usize) -> Vec<DensePolynom
 }
 
 fn fold_quotient_chunks<F: Field>(chunks: &[DensePolynomial<F>], z_to_n: F) -> DensePolynomial<F> {
-    chunks.iter()
+    chunks
+        .iter()
         .zip(utils::powers(z_to_n))
         .map(|(chunk, coeff)| chunk * coeff)
         .reduce(|acc, new| acc + new)
@@ -20,13 +21,12 @@ fn fold_quotient_chunks<F: Field>(chunks: &[DensePolynomial<F>], z_to_n: F) -> D
 }
 
 fn quotient_commitment<F: PrimeField, C: Commitment<F>>(chunks: &[C], z_to_n: F) -> C {
-    chunks.iter()
+    chunks
+        .iter()
         .zip(utils::powers(z_to_n))
         .map(|(chunk, coeff)| chunk.mul(coeff))
         .sum()
 }
 
 #[cfg(test)]
-mod tests {
-
-}
+mod tests {}

--- a/w3f-plonk-common/src/q_chunking.rs
+++ b/w3f-plonk-common/src/q_chunking.rs
@@ -11,7 +11,10 @@ pub fn chunk_quotient<F: Field>(q: DensePolynomial<F>, n: usize) -> Vec<DensePol
         .collect()
 }
 
-pub fn fold_quotient_chunks<F: Field>(chunks: &[DensePolynomial<F>], z_to_n: F) -> DensePolynomial<F> {
+pub fn fold_quotient_chunks<F: Field>(
+    chunks: &[DensePolynomial<F>],
+    z_to_n: F,
+) -> DensePolynomial<F> {
     chunks
         .iter()
         .zip(utils::powers(z_to_n))

--- a/w3f-plonk-common/src/verifier.rs
+++ b/w3f-plonk-common/src/verifier.rs
@@ -56,7 +56,8 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkVerifier<F, CS, 
         // q(X) = q0(X) + q1(X)X^n + q2(X)X^{2n} (+ ... + qk(X)X^{kn})
         // Let q_z(X) = q0(X) + q1(X).z^n + q2(X).z^{2n}
         // then q_z(z) = q(z)
-        let quotient_commitment = q_chunking::compose_quotient(&proof.quotient_chunks, piop.domain_evaluated().z_n);
+        let quotient_commitment =
+            q_chunking::compose_quotient(&proof.quotient_chunks, piop.domain_evaluated().z_n);
         open_at_zeta.push(quotient_commitment);
 
         let mut vals_at_zeta = proof.columns_at_zeta.to_vec();

--- a/w3f-plonk-common/src/verifier.rs
+++ b/w3f-plonk-common/src/verifier.rs
@@ -6,7 +6,7 @@ use w3f_pcs::pcs::{Commitment, PcsParams, PCS};
 
 use crate::piop::VerifierPiop;
 use crate::transcript::PlonkTranscript;
-use crate::{ColumnsCommited, ColumnsEvaluated, PiopProof, Proof};
+use crate::{q_chunking, ColumnsCommited, ColumnsEvaluated, PiopProof, Proof};
 
 pub struct PlonkVerifier<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> {
     // Polynomial commitment scheme verifier's key.
@@ -53,7 +53,11 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkVerifier<F, CS, 
     {
         let mut open_at_zeta = piop.precommitted_columns();
         open_at_zeta.extend(proof.column_commitments.to_vec());
-        open_at_zeta.extend(proof.quotient_chunks);
+        // q(X) = q0(X) + q1(X)X^n + q2(X)X^{2n} (+ ... + qk(X)X^{kn})
+        // Let q_z(X) = q0(X) + q1(X).z^n + q2(X).z^{2n}
+        // then q_z(z) = q(z)
+        let quotient_commitment = q_chunking::compose_quotient(&proof.quotient_chunks, piop.domain_evaluated().z_n);
+        open_at_zeta.push(quotient_commitment);
 
         let mut vals_at_zeta = proof.columns_at_zeta.to_vec();
         let q_zeta = piop.evaluate_q_at_zeta(&challenges.alphas, proof.lin_at_zeta_omega);

--- a/w3f-plonk-common/src/verifier.rs
+++ b/w3f-plonk-common/src/verifier.rs
@@ -53,7 +53,7 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkVerifier<F, CS, 
     {
         let mut open_at_zeta = piop.precommitted_columns();
         open_at_zeta.extend(proof.column_commitments.to_vec());
-        open_at_zeta.push(proof.quotient_commitment.clone());
+        open_at_zeta.extend(proof.quotient_chunks);
 
         let mut vals_at_zeta = proof.columns_at_zeta.to_vec();
         let q_zeta = piop.evaluate_q_at_zeta(&challenges.alphas, proof.lin_at_zeta_omega);
@@ -134,7 +134,9 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkVerifier<F, CS, 
         // let r = transcript.get_bitmask_aggregation_challenge();
         // transcript.append_2nd_round_register_commitments(&proof.additional_commitments);
         let alphas = transcript.get_constraints_aggregation_coeffs(n_constraints);
-        transcript.add_quotient_commitment(&proof.quotient_commitment);
+        for quotient_chunk in proof.quotient_chunks.iter() {
+            transcript.add_quotient_commitment(quotient_chunk);
+        }
         let zeta = transcript.get_evaluation_point();
         transcript.add_evaluations(&proof.columns_at_zeta, &proof.lin_at_zeta_omega);
         let nus = transcript.get_kzg_aggregation_challenges(n_polys);


### PR DESCRIPTION
Standard Plonk, as well as our [ring-proof crate](https://github.com/paritytech/ring-proof/tree/master/w3f-ring-proof) uses non hiding version of the KZG commitment scheme. That requires blinding the chunks as described in https://eprint.iacr.org/2024/848, but we don't do chunking in the ring-proof.

For pasta curves i set `ZK_ROWS = 2` and assume that every commitment that isn't public is a Pedersen **hiding** commitment. So the chunks aren't additionally blinded. That makes the quotient fit `3` chunks. The highest constraint degree is `deg(c) = 4n - 3` for the conditional affine addition. `deg(q) = deg(c) - deg(z)`, where `z(X) = (X^n - 1) / (X - w^{n-1})(X - w^{n-2})`, `deg(z) = n - 2`. So `deg(q) = (4n-3) - (n-2) = 3n-1` and `q` has `3n` coefficients.