### PR TITLE
consts cleaned up a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = [
 #    "evm-vrfier",
-    "pasta-tree",
+#    "pasta-tree",
     "w3f-plonk-common",
     "w3f-ring-proof",
     #    "w3f-ring-vrf-snark",

--- a/pasta-tree/src/level/verifier.rs
+++ b/pasta-tree/src/level/verifier.rs
@@ -39,9 +39,6 @@ impl<C: CurveGroup, G: SWCurveConfig<BaseField = C::ScalarField, ScalarField = C
         let (challenges, _rng) = plonk_verifier.restore_challenges(
             &blinded_child,
             &piop_proof,
-            // '1' accounts for the quotient polynomial that is aggregated together with the columns
-            PiopVerifier::<C::ScalarField, IPACommitment<C>, Affine<G>>::N_COLUMNS + 1,
-            PiopVerifier::<C::ScalarField, IPACommitment<C>, Affine<G>>::N_CONSTRAINTS,
         );
         let seed = self.piop_params.seed;
         let seed_plus_result = (seed + blinded_child).into_affine();

--- a/w3f-plonk-common/src/piop.rs
+++ b/w3f-plonk-common/src/piop.rs
@@ -9,6 +9,7 @@ use crate::domain::{Domain, EvaluatedDomain};
 use crate::{ColumnsCommited, ColumnsEvaluated};
 
 pub trait ProverPiop<F: PrimeField, C: Commitment<F>> {
+    const N_COLUMNS: usize;
     const N_CONSTRAINTS: usize;
 
     type Commitments: ColumnsCommited<F, C>;
@@ -78,8 +79,9 @@ pub fn aggregate_evaluations<F: FftField>(
 }
 
 pub trait VerifierPiop<F: PrimeField, C: Commitment<F>> {
-    const N_CONSTRAINTS: usize;
     const N_COLUMNS: usize;
+    const N_CONSTRAINTS: usize;
+    type Instance: CanonicalSerialize + CanonicalDeserialize;
     // Columns the commitments to which are publicly known. These commitments are omitted from the proof.
     fn precommitted_columns(&self) -> Vec<C>;
 

--- a/w3f-plonk-common/src/verifier.rs
+++ b/w3f-plonk-common/src/verifier.rs
@@ -2,6 +2,7 @@ use ark_ff::{Field, PrimeField};
 use ark_serialize::CanonicalSerialize;
 use ark_std::rand::Rng;
 use ark_std::{vec, vec::Vec};
+use rand_core::RngCore;
 use w3f_pcs::pcs::{Commitment, PcsParams, PCS};
 
 use crate::piop::VerifierPiop;
@@ -117,7 +118,7 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkVerifier<F, CS, 
         .is_ok()
     }
 
-    pub fn restore_challenges<Piop, Cols, Evals>(
+    pub fn _restore_challenges<Piop, Cols, Evals>(
         &self,
         instance: &Piop::Instance,
         proof: &PiopProof<F, CS::C, Cols, Evals>,
@@ -136,9 +137,38 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkVerifier<F, CS, 
         transcript.add_quotient_commitment(&proof.quotient_commitment);
         let zeta = transcript.get_evaluation_point();
         transcript.add_evaluations(&proof.columns_at_zeta, &proof.lin_at_zeta_omega);
-        let nus = transcript.get_kzg_aggregation_challenges(Piop::N_COLUMNS + 1); //TODO: chunks
+        let nus = transcript.get_kzg_aggregation_challenges(Piop::N_COLUMNS + 1);
         let challenges = Challenges { alphas, zeta, nus };
         (challenges, transcript)
+    }
+
+    pub fn restore_fs_challenges<Piop, Cols, Evals>(
+        &self,
+        instance: &Piop::Instance,
+        proof: &PiopProof<F, CS::C, Cols, Evals>,
+    ) -> Challenges<F>
+    where
+        Piop: VerifierPiop<F, CS::C>,
+        Cols: ColumnsCommited<F, CS::C>,
+        Evals: ColumnsEvaluated<F>,
+    {
+        self._restore_challenges::<Piop, _, _>(instance, proof).0
+    }
+
+    pub fn restore_fs_with_rng<Piop, Cols, Evals>(
+        &self,
+        instance: &Piop::Instance,
+        proof: &Proof<F, CS, Cols, Evals>,
+    ) -> (Challenges<F>, impl RngCore)
+    where
+        Piop: VerifierPiop<F, CS::C>,
+        Cols: ColumnsCommited<F, CS::C>,
+        Evals: ColumnsEvaluated<F>,
+    {
+        let (challenges, mut transcript) =
+            self._restore_challenges::<Piop, _, _>(instance, &proof.to_piop_proof());
+        transcript.add_kzg_proofs(&proof.agg_at_zeta_proof, &proof.lin_at_zeta_omega_proof);
+        (challenges, transcript.to_rng())
     }
 }
 

--- a/w3f-plonk-common/src/verifier.rs
+++ b/w3f-plonk-common/src/verifier.rs
@@ -117,27 +117,26 @@ impl<F: PrimeField, CS: PCS<F>, T: PlonkTranscript<F, CS>> PlonkVerifier<F, CS, 
         .is_ok()
     }
 
-    pub fn restore_challenges<Commitments, Evaluations>(
+    pub fn restore_challenges<Piop, Cols, Evals>(
         &self,
-        instance: &impl CanonicalSerialize,
-        proof: &PiopProof<F, CS::C, Commitments, Evaluations>,
-        n_polys: usize,
-        n_constraints: usize,
+        instance: &Piop::Instance,
+        proof: &PiopProof<F, CS::C, Cols, Evals>,
     ) -> (Challenges<F>, T)
     where
-        Commitments: ColumnsCommited<F, CS::C>,
-        Evaluations: ColumnsEvaluated<F>,
+        Piop: VerifierPiop<F, CS::C>,
+        Cols: ColumnsCommited<F, CS::C>,
+        Evals: ColumnsEvaluated<F>,
     {
         let mut transcript = self.transcript_prelude.clone();
         transcript.add_instance(instance);
         transcript.add_committed_cols(&proof.column_commitments);
         // let r = transcript.get_bitmask_aggregation_challenge();
         // transcript.append_2nd_round_register_commitments(&proof.additional_commitments);
-        let alphas = transcript.get_constraints_aggregation_coeffs(n_constraints);
+        let alphas = transcript.get_constraints_aggregation_coeffs(Piop::N_CONSTRAINTS);
         transcript.add_quotient_commitment(&proof.quotient_commitment);
         let zeta = transcript.get_evaluation_point();
         transcript.add_evaluations(&proof.columns_at_zeta, &proof.lin_at_zeta_omega);
-        let nus = transcript.get_kzg_aggregation_challenges(n_polys);
+        let nus = transcript.get_kzg_aggregation_challenges(Piop::N_COLUMNS + 1); //TODO: chunks
         let challenges = Challenges { alphas, zeta, nus };
         (challenges, transcript)
     }

--- a/w3f-ring-proof/src/multi_ring_batch_verifier.rs
+++ b/w3f-ring-proof/src/multi_ring_batch_verifier.rs
@@ -6,7 +6,6 @@ use w3f_pcs::pcs::kzg::params::KzgVerifierKey;
 use w3f_pcs::pcs::kzg::KZG;
 use w3f_pcs::pcs::PCS;
 use w3f_plonk_common::kzg_acc::KzgAccumulator;
-use w3f_plonk_common::piop::VerifierPiop;
 use w3f_plonk_common::transcript::PlonkTranscript;
 use w3f_plonk_common::verifier::Challenges;
 
@@ -44,12 +43,12 @@ where
     where
         T: PlonkTranscript<E::ScalarField, KZG<E>>,
     {
-        let (challenges, mut transcript) = verifier.plonk_verifier.restore_challenges(
-            &result,
-            &proof.to_piop_proof(),
-            PiopVerifier::<E::ScalarField, <KZG<E> as PCS<_>>::C, Affine<J>>::N_COLUMNS + 1,
-            PiopVerifier::<E::ScalarField, <KZG<E> as PCS<_>>::C, Affine<J>>::N_CONSTRAINTS,
-        );
+        let (challenges, mut transcript) = verifier
+            .plonk_verifier
+            .restore_challenges::<PiopVerifier<_, _, Affine<J>>, _, _>(
+                &result,
+                &proof.to_piop_proof(),
+            );
         transcript.add_kzg_proofs(&proof.agg_at_zeta_proof, &proof.lin_at_zeta_omega_proof);
         let seed = verifier.piop_params.seed;
         let seed_plus_result = (seed + result).into_affine();

--- a/w3f-ring-proof/src/multi_ring_batch_verifier.rs
+++ b/w3f-ring-proof/src/multi_ring_batch_verifier.rs
@@ -43,13 +43,9 @@ where
     where
         T: PlonkTranscript<E::ScalarField, KZG<E>>,
     {
-        let (challenges, mut transcript) = verifier
+        let (challenges, mut fs_rng) = verifier
             .plonk_verifier
-            .restore_challenges::<PiopVerifier<_, _, Affine<J>>, _, _>(
-                &result,
-                &proof.to_piop_proof(),
-            );
-        transcript.add_kzg_proofs(&proof.agg_at_zeta_proof, &proof.lin_at_zeta_omega_proof);
+            .restore_fs_with_rng::<PiopVerifier<_, _, Affine<J>>, _, _>(&result, &proof);
         let seed = verifier.piop_params.seed;
         let seed_plus_result = (seed + result).into_affine();
         let domain_at_zeta = verifier.piop_params.domain.evaluate(challenges.zeta);
@@ -63,7 +59,7 @@ where
         );
 
         let mut entropy = [0_u8; 32];
-        transcript.to_rng().fill_bytes(&mut entropy);
+        fs_rng.fill_bytes(&mut entropy);
 
         Self {
             piop,

--- a/w3f-ring-proof/src/piop/prover.rs
+++ b/w3f-ring-proof/src/piop/prover.rs
@@ -146,6 +146,7 @@ where
     C: Commitment<F>,
     Curve: TECurveConfig<BaseField = F>,
 {
+    const N_COLUMNS: usize = 7;
     const N_CONSTRAINTS: usize = 7;
 
     type Commitments = RingCommitments<F, C>;
@@ -208,8 +209,8 @@ where
     C: Commitment<F>,
     Curve: SWCurveConfig<BaseField = F>,
 {
+    const N_COLUMNS: usize = 7;
     const N_CONSTRAINTS: usize = 7;
-
     type Commitments = RingCommitments<F, C>;
     type Evaluations = RingEvaluations<F>;
     type Instance = SwAffine<Curve>;

--- a/w3f-ring-proof/src/piop/verifier.rs
+++ b/w3f-ring-proof/src/piop/verifier.rs
@@ -12,9 +12,10 @@ use w3f_plonk_common::gadgets::ec::CondAddValues;
 use w3f_plonk_common::gadgets::fixed_cells::FixedCellsValues;
 use w3f_plonk_common::gadgets::inner_prod::InnerProdValues;
 use w3f_plonk_common::gadgets::VerifierGadget;
+use w3f_plonk_common::piop::ProverPiop;
 use w3f_plonk_common::piop::VerifierPiop;
 
-use crate::piop::{FixedColumnsCommitted, RingCommitments};
+use crate::piop::{FixedColumnsCommitted, PiopProver, RingCommitments};
 use crate::RingEvaluations;
 
 pub struct PiopVerifier<F: PrimeField, C: Commitment<F>, P: AffineRepr<BaseField = F>> {
@@ -105,8 +106,10 @@ impl<F: PrimeField, C: Commitment<F>, P: AffineRepr<BaseField = F>> PiopVerifier
 impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> VerifierPiop<F, C>
     for PiopVerifier<F, C, TeAffine<Jubjub>>
 {
-    const N_CONSTRAINTS: usize = 7;
-    const N_COLUMNS: usize = 7;
+    const N_COLUMNS: usize = <PiopProver<F, TeAffine<Jubjub>> as ProverPiop<F, C>>::N_COLUMNS;
+    const N_CONSTRAINTS: usize =
+        <PiopProver<F, TeAffine<Jubjub>> as ProverPiop<F, C>>::N_CONSTRAINTS;
+    type Instance = <PiopProver<F, TeAffine<Jubjub>> as ProverPiop<F, C>>::Instance;
 
     fn precommitted_columns(&self) -> Vec<C> {
         self.fixed_columns_committed.as_vec()
@@ -153,8 +156,10 @@ impl<F: PrimeField, C: Commitment<F>, Jubjub: TECurveConfig<BaseField = F>> Veri
 impl<F: PrimeField, C: Commitment<F>, Jubjub: SWCurveConfig<BaseField = F>> VerifierPiop<F, C>
     for PiopVerifier<F, C, SwAffine<Jubjub>>
 {
-    const N_CONSTRAINTS: usize = 7;
-    const N_COLUMNS: usize = 7;
+    const N_COLUMNS: usize = <PiopProver<F, SwAffine<Jubjub>> as ProverPiop<F, C>>::N_COLUMNS;
+    const N_CONSTRAINTS: usize =
+        <PiopProver<F, SwAffine<Jubjub>> as ProverPiop<F, C>>::N_CONSTRAINTS;
+    type Instance = <PiopProver<F, SwAffine<Jubjub>> as ProverPiop<F, C>>::Instance;
 
     fn precommitted_columns(&self) -> Vec<C> {
         self.fixed_columns_committed.as_vec()

--- a/w3f-ring-proof/src/ring_verifier.rs
+++ b/w3f-ring-proof/src/ring_verifier.rs
@@ -4,7 +4,6 @@ use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use w3f_pcs::pcs::kzg::KZG;
 use w3f_pcs::pcs::{RawVerifierKey, PCS};
-use w3f_plonk_common::piop::VerifierPiop;
 use w3f_plonk_common::transcript::PlonkTranscript;
 use w3f_plonk_common::verifier::PlonkVerifier;
 
@@ -48,13 +47,12 @@ where
     }
 
     pub fn verify(&self, proof: RingProof<F, CS>, result: Affine<Jubjub>) -> bool {
-        let (challenges, mut transcript) = self.plonk_verifier.restore_challenges(
-            &result,
-            &proof.to_piop_proof(),
-            // '1' accounts for the quotient polynomial that is aggregated together with the columns
-            PiopVerifier::<F, CS::C, Affine<Jubjub>>::N_COLUMNS + 1,
-            PiopVerifier::<F, CS::C, Affine<Jubjub>>::N_CONSTRAINTS,
-        );
+        let (challenges, mut transcript) = self
+            .plonk_verifier
+            .restore_challenges::<PiopVerifier<_, _, Affine<Jubjub>>, _, _>(
+                &result,
+                &proof.to_piop_proof(),
+            );
         transcript.add_kzg_proofs(&proof.agg_at_zeta_proof, &proof.lin_at_zeta_omega_proof);
         let seed = self.piop_params.seed;
         let seed_plus_result = (seed + result).into_affine();

--- a/w3f-ring-proof/src/ring_verifier.rs
+++ b/w3f-ring-proof/src/ring_verifier.rs
@@ -47,13 +47,9 @@ where
     }
 
     pub fn verify(&self, proof: RingProof<F, CS>, result: Affine<Jubjub>) -> bool {
-        let (challenges, mut transcript) = self
+        let (challenges, mut fs_rng) = self
             .plonk_verifier
-            .restore_challenges::<PiopVerifier<_, _, Affine<Jubjub>>, _, _>(
-                &result,
-                &proof.to_piop_proof(),
-            );
-        transcript.add_kzg_proofs(&proof.agg_at_zeta_proof, &proof.lin_at_zeta_omega_proof);
+            .restore_fs_with_rng::<PiopVerifier<_, _, Affine<Jubjub>>, _, _>(&result, &proof);
         let seed = self.piop_params.seed;
         let seed_plus_result = (seed + result).into_affine();
         let domain_at_zeta = self.piop_params.domain.evaluate(challenges.zeta);
@@ -67,7 +63,7 @@ where
         );
 
         self.plonk_verifier
-            .verify(piop, proof, challenges, &mut transcript.to_rng())
+            .verify(piop, proof, challenges, &mut fs_rng)
     }
 
     pub fn piop_params(&self) -> &PiopParams<Affine<Jubjub>> {


### PR DESCRIPTION
I think we'll eventually move some lighter version of `pasta_tree:CircuitParams` to `plonk-common` and keep the constants there.